### PR TITLE
renamed the existsing Strings\split() to Strings\splitByLength() and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ If you would like to contribute to this project, please feel to fork the project
    * `Numbers\isMultipleOf()`
    * `Numbers\isFactorOf()`
    * `Strings\isBlank()`
+   * `Strings\splitByLength()`
    * `GeneralFunctions\ifThen()`
    * `GeneralFunctions\ifElse()`
    * `GeneralFunctions\composeR()`
@@ -588,6 +589,7 @@ If you would like to contribute to this project, please feel to fork the project
    * `Strings\tagWrap()` has been removed
    * `Strings\asUrl()` has been removed
    * `Strings\vSprintf()` has has its arguments reversed.
+   * `Strings\split()` is now a wrapper for explode() and the existing `Strings\split()` has been renamed to `Strings\splitByLength()`
    * **Other Changes**
    * Constants added using the `Functions` class-name, `Functions::isBlank` can be used as a string for a callable.
    * `GeneralFunctions\toArray()` has been moved to `Objects\toArray()`, `Objects\toArray()` is now an alias for `GeneralFunctions\toArray()`

--- a/Tests/test-strings.php
+++ b/Tests/test-strings.php
@@ -224,11 +224,33 @@ class StringFunctionTest extends TestCase
         $this->assertEquals('h\appy \d\ays', $slashAD('happy days'));
     }
 
-    public function testCanSplitString()
+    public function testCanSplitStringByLength()
     {
-        $splitIntoFours = Str\split(4);
+        $splitIntoFours = Str\splitByLength(4);
 
         $split = $splitIntoFours('AAAABBBBCCCCDDDD');
+        $this->assertEquals('AAAA', $split[0]);
+        $this->assertEquals('BBBB', $split[1]);
+        $this->assertEquals('CCCC', $split[2]);
+        $this->assertEquals('DDDD', $split[3]);
+    }
+
+    /** @testdox It should be possible to split a string into an array using a define separator and using the limit */
+    public function testCanSplitStringBySeperatorAndLimit()
+    {
+        $splitByComma = Str\split(',', 2);
+
+        $split = $splitByComma('AAAA,BBBB,CCCC,DDDD');
+        $this->assertEquals('AAAA', $split[0]);
+        $this->assertEquals('BBBB,CCCC,DDDD', $split[1]);
+    }
+
+    /** @testdox It should be possible to split a string into an array using a defined separator with an unlimited limit.  */
+    public function testCanSplitStringBySeperatorAndUnlimitedLimit()
+    {
+        $splitByComma = Str\split(',');
+
+        $split = $splitByComma('AAAA,BBBB,CCCC,DDDD');
         $this->assertEquals('AAAA', $split[0]);
         $this->assertEquals('BBBB', $split[1]);
         $this->assertEquals('CCCC', $split[2]);

--- a/src/strings.php
+++ b/src/strings.php
@@ -319,10 +319,27 @@ function addSlashes(string $charList): Closure
 /**
  * Returns a callable for splitting a string by a set amount.
  *
+ * @param int $limit The number of chars to split by.
+ * @return Closure(string):array<string> The parts.
+ */
+function split(string $separator, int $limit = PHP_INT_MAX): Closure
+{
+    /**
+     * @param string $string The string to be split
+     * @return array<int, string>
+     */
+    return function (string $string) use ($separator, $limit): array {
+        return explode($separator, $string, $limit); // @phpstan-ignore-line, inconsistent errors with differing php versions.
+    };
+}
+
+/**
+ * Returns a callable for splitting a string by a set amount.
+ *
  * @param int $length The length to split the string up with.
  * @return Closure(string):array<string> The parts.
  */
-function split(int $length): Closure
+function splitByLength(int $length): Closure
 {
     /**
      * @param string $string The string to be split
@@ -332,6 +349,7 @@ function split(int $length): Closure
         return \str_split($string, max(1, $length)) ?: array(); // @phpstan-ignore-line, inconsistent errors with differing php versions.
     };
 }
+
 
 /**
  * Returns a callback for splitting a string into chunks.


### PR DESCRIPTION
…made Strings\split() be a wrapper for explode(). This would make the lib more in line with other languages