### PR TITLE
Rename the tail() function to last() and implement correct tail()

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -567,9 +567,11 @@ If you would like to contribute to this project, please feel to fork the project
   * `Strings\digit()`
   * `Strings\compare()` 
   * `Strings\countChars()` now has mode constants.
+  * `Arrays\last()` will return the last element of an array.
   * **Breaking Changes**
   * `Strings\decimalNumber()` has been deprecated in favour of `Strings\digit()`
   * `Strings\similarAsBase()` and `Strings\similarAsComparison()` have been deprecated in favour of `Strings\similar()`
+  * `Arrays\tail()` now works as expected, returning the array without the first element.
 
 
 * 0.2.0 - 

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -75,9 +75,21 @@ class ArrayFunctionTests extends TestCase
     public function testCanUseTail()
     {
         $names = array('Sam Smith', 'Barry Smith', 'Sam Power', 'Rebecca Smith');
-        $this->assertEquals('Rebecca Smith', Arr\tail($names));
+        $this->assertEquals(
+            array('Barry Smith', 'Sam Power', 'Rebecca Smith'),
+            Arr\tail($names)
+        );
         // Check returns null if empty.
         $this->assertNull(Arr\tail(array()));
+    }
+
+    /** @testdox It should be possible to get the last item from an array */
+    public function testCanUseLast()
+    {
+        $names = array('Sam Smith', 'Barry Smith', 'Sam Power', 'Rebecca Smith');
+        $this->assertEquals('Rebecca Smith', Arr\last($names));
+        // Check returns null if empty.
+        $this->assertNull(Arr\last(array()));
     }
 
     public function testCanUseHead()
@@ -237,7 +249,7 @@ class ArrayFunctionTests extends TestCase
             1,
             2,
             array(),
-            array( 3, 4 ),
+            array(3, 4),
             array(
                 5,
                 6,
@@ -454,8 +466,8 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to create a function which allows for calling scan on a passed array */
     public function testScanL(): void
     {
-        $initial  = array( 1, 2, 3, 4, 5 );
-        $expected = array( 0, 1, 3, 6, 10, 15 );
+        $initial  = array(1, 2, 3, 4, 5);
+        $expected = array(0, 1, 3, 6, 10, 15);
 
         $scan = Arr\scan(
             function ($carry, $item) {
@@ -474,16 +486,16 @@ class ArrayFunctionTests extends TestCase
             0
         );
 
-        $data     = array( 1, 3, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9 );
-        $expected = array( 0, 1, 3, 4, 4, 5, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 );
+        $data     = array(1, 3, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9);
+        $expected = array(0, 1, 3, 4, 4, 5, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9);
         $this->assertEquals($expected, $max($data));
     }
 
     /** @testdox It should be possible to create a function which allows for calling scanr on a passed array.     */
     public function testScanR(): void
     {
-        $initial  = array( 1, 2, 3 );
-        $expected = array( 6, 5, 3, 0 );
+        $initial  = array(1, 2, 3);
+        $expected = array(6, 5, 3, 0);
 
         $scanR = Arr\scanR(
             function ($carry, $item) {
@@ -498,8 +510,8 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to create a function, pre defined to perform fold/reduce on a given array. */
     public function testFold(): void
     {
-        $sumMe   = array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
-        $biggest = array( 1, 5, 6, 7, 10, 2 );
+        $sumMe   = array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        $biggest = array(1, 5, 6, 7, 10, 2);
 
         $findSum     = Arr\fold(
             function (int $carry, int $current) {
@@ -521,7 +533,7 @@ class ArrayFunctionTests extends TestCase
     /** @testdox  It should be possible to create a function, pre defined to perform fold/reduce on a given array in reverse order. */
     public function testFoldR(): void
     {
-        $data      = array( 'a', 'b', 'c', 'd' );
+        $data      = array('a', 'b', 'c', 'd');
         $joinArray = Arr\foldR(
             function (string $carry, string $value): string {
                 return $carry . $value;
@@ -542,7 +554,7 @@ class ArrayFunctionTests extends TestCase
             4 => 4,
             0 => 0,
         );
-        $expected = array( 'key-1::value-1', 'key-3::value-3', 'key-2::value-2', 'key-5::value-5', 'key-4::value-4', 'key-0::value-0' );
+        $expected = array('key-1::value-1', 'key-3::value-3', 'key-2::value-2', 'key-5::value-5', 'key-4::value-4', 'key-0::value-0');
 
         $foldWithKeys = Arr\foldKeys(
             function (array $carry, int $key, int $value): array {
@@ -557,14 +569,14 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to take n number of elements from an array using Arr\take() */
     public function testTake(): void
     {
-        $data     = array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
-        $expected = array( 1, 2, 3, 4, 5 );
+        $data     = array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        $expected = array(1, 2, 3, 4, 5);
 
         $take5 = Arr\take(5);
         $this->assertEquals($expected, $take5($data));
 
         $take3 = Arr\take(3);
-        $this->assertEquals(array( 1, 2, 3 ), $take3($data));
+        $this->assertEquals(array(1, 2, 3), $take3($data));
 
         $take0 = Arr\take(0);
         $this->assertEquals(array(), $take0($data));
@@ -585,14 +597,14 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to take n number of elements from an array using Arr\takeLast() */
     public function testTakeLast(): void
     {
-        $data     = array( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
-        $expected = array( 5, 6, 7, 8, 9 );
+        $data     = array(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        $expected = array(5, 6, 7, 8, 9);
 
         $take5 = Arr\takeLast(5);
         $this->assertEquals($expected, $take5($data));
 
         $take3 = Arr\takeLast(3);
-        $this->assertEquals(array( 7, 8, 9 ), $take3($data));
+        $this->assertEquals(array(7, 8, 9), $take3($data));
 
         $take0 = Arr\takeLast(0);
         $this->assertEquals(array(), $take0($data));
@@ -613,8 +625,8 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible return an array which includes all values until the callback returns true using Arr\takeUntil() */
     public function testTakeUntil(): void
     {
-        $data     = array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
-        $expected = array( 1, 2, 3, 4, 5, 6, 7, 8 );
+        $data     = array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        $expected = array(1, 2, 3, 4, 5, 6, 7, 8);
 
         $takeUntil = Arr\takeUntil(
             function ($value) {
@@ -641,8 +653,8 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to return an array which includes all values until the callback returns false using Arr\takeWhile() */
     public function testTakeWhile(): void
     {
-        $data     = array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
-        $expected = array( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
+        $data     = array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        $expected = array(1, 2, 3, 4, 5, 6, 7, 8, 9);
 
         $takeWhile = Arr\takeWhile(
             function ($value) {
@@ -656,7 +668,7 @@ class ArrayFunctionTests extends TestCase
                 return $value < 5;
             }
         );
-        $this->assertEquals(array( 1, 2, 3, 4 ), $takeWhile($data));
+        $this->assertEquals(array(1, 2, 3, 4), $takeWhile($data));
 
         $takeWhile = Arr\takeWhile(
             function ($value) {
@@ -674,7 +686,7 @@ class ArrayFunctionTests extends TestCase
             'b' => 'anana',
             'c' => 'arrot',
         );
-        $expected = array( 'apple', 'banana', 'carrot' );
+        $expected = array('apple', 'banana', 'carrot');
 
         $map = Arr\mapWithKey(
             function (string $key, string $value) {
@@ -707,7 +719,7 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to create a function that is populated with a filter predicate, which when used on an array will return a count of matching values. */
     public function testCountBy(): void
     {
-        $data = array( 'aa', 'aa', 'bb', 'bb', 'vvvv', 'vvvv', 'vvvv' );
+        $data = array('aa', 'aa', 'bb', 'bb', 'vvvv', 'vvvv', 'vvvv');
 
         $countAa = Arr\filterCount(
             function (string $value) {
@@ -832,113 +844,113 @@ class ArrayFunctionTests extends TestCase
     /** @testdox It should be possible to use rsort with predefined flags and not have the original array changed (immuteable) */
     public function testRsort(): void
     {
-        $data = array( 1, 2, 3, 4, 5 );
+        $data = array(1, 2, 3, 4, 5);
 
         $rsort = Arr\rsort();
-        $this->assertEquals(array( 5, 4, 3, 2, 1 ), $rsort($data));
-        $this->assertEquals(array( 1, 2, 3, 4, 5 ), $data);
+        $this->assertEquals(array(5, 4, 3, 2, 1), $rsort($data));
+        $this->assertEquals(array(1, 2, 3, 4, 5), $data);
 
         $rsort = Arr\rsort(SORT_NUMERIC);
-        $this->assertEquals(array( 5, 4, 3, 2, 1 ), $rsort($data));
-        $this->assertEquals(array( 1, 2, 3, 4, 5 ), $data);
+        $this->assertEquals(array(5, 4, 3, 2, 1), $rsort($data));
+        $this->assertEquals(array(1, 2, 3, 4, 5), $data);
 
         // Passed as reference
         $rsort = Arr\rsort(SORT_NUMERIC);
         $foo = &$data;
-        $this->assertEquals(array( 5, 4, 3, 2, 1 ), $rsort($foo));
-        $this->assertEquals(array( 1, 2, 3, 4, 5 ), $data);
+        $this->assertEquals(array(5, 4, 3, 2, 1), $rsort($foo));
+        $this->assertEquals(array(1, 2, 3, 4, 5), $data);
     }
 
     /** testdox It should be possible to use krsort with predefined flags and not have the original array changed */
     public function testKrsort(): void
     {
-        $data = array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 );
+        $data = array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5);
 
         $krsort = Arr\krsort();
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $krsort($data));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $krsort($data));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
 
         $krsort = Arr\krsort(SORT_NUMERIC);
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $krsort($data));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $krsort($data));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
 
         // Passed as reference
         $krsort = Arr\krsort(SORT_NUMERIC);
         $foo = &$data;
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $krsort($foo));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $krsort($foo));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
     }
 
     /** testdox It should be possible to use arsort with predefined flags and not have the original array changed */
     public function testArsort(): void
     {
-        $data = array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 );
+        $data = array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5);
 
         $arsort = Arr\arsort();
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $arsort($data));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $arsort($data));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
 
         $arsort = Arr\arsort(SORT_NUMERIC);
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $arsort($data));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $arsort($data));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
 
         // Passed as reference
         $arsort = Arr\arsort(SORT_NUMERIC);
         $foo = &$data;
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $arsort($foo));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $arsort($foo));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
     }
 
     /** testdox It should be possible to use asort with predefined flags and not have the original array changed */
     public function testAsort(): void
     {
-        $data = array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 );
+        $data = array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5);
 
         $asort = Arr\asort();
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $asort($data));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $asort($data));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
 
         $asort = Arr\asort(SORT_NUMERIC);
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $asort($data));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $asort($data));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
 
         // Passed as reference
         $asort = Arr\asort(SORT_NUMERIC);
         $foo = &$data;
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $asort($foo));
-        $this->assertEquals(array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ), $data);
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $asort($foo));
+        $this->assertEquals(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5), $data);
     }
 
     /** testdox It should be possible to use natcasesort with predefined flags and not have the original array changed */
     public function testNatcasesort(): void
     {
-        $data = array( 'a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E' );
+        $data = array('a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E');
 
         $natcasesort = Arr\natcasesort();
-        $this->assertEquals(array( 'a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E' ), $natcasesort($data));
-        $this->assertEquals(array( 'a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E' ), $data);
+        $this->assertEquals(array('a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E'), $natcasesort($data));
+        $this->assertEquals(array('a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E'), $data);
 
         // Passed as reference
         $natcasesort = Arr\natcasesort();
         $foo = &$data;
-        $this->assertEquals(array( 'a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E' ), $natcasesort($foo));
-        $this->assertEquals(array( 'a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E' ), $data);
+        $this->assertEquals(array('a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E'), $natcasesort($foo));
+        $this->assertEquals(array('a' => 'a', 'b' => 'B', 'c' => 'C', 'd' => 'd', 'e' => 'E'), $data);
     }
 
     /** testdox It should be possible to use uksort with predefined flags and not have the original array changed */
     public function testUksort(): void
     {
-        $data = array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 );
+        $data = array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5);
         $sortHighToLow = function ($a, $b) {
             return $b <=> $a;
         };
 
         $uksort = Arr\uksort($sortHighToLow);
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $uksort($data));
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $uksort($data));
 
         // Passed as reference
         $uksort = Arr\uksort($sortHighToLow);
         $foo = &$data;
-        $this->assertEquals(array( 'e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1 ), $uksort($foo));
+        $this->assertEquals(array('e' => 5, 'd' => 4, 'c' => 3, 'b' => 2, 'a' => 1), $uksort($foo));
     }
 }

--- a/Tests/test-function-constants.php
+++ b/Tests/test-function-constants.php
@@ -13,7 +13,7 @@ class FunctionConstantsTest extends TestCase
     public function testNotEmptyConstant()
     {
         // With arrays
-        $this->assertTrue(call_user_func(Functions::NOT_EMPTY, array( 'test' )));
+        $this->assertTrue(call_user_func(Functions::NOT_EMPTY, array('test')));
         $this->assertFalse(call_user_func(Functions::NOT_EMPTY, array()));
 
         // With strings
@@ -24,15 +24,15 @@ class FunctionConstantsTest extends TestCase
     /** @testdox It should be possible to use a constant for Arrays\head() as a callable */
     public function testArrayHead(): void
     {
-        $this->assertEquals('1', call_user_func(Functions::ARRAY_HEAD, array( '1', '2' )));
+        $this->assertEquals('1', call_user_func(Functions::ARRAY_HEAD, array('1', '2')));
         $this->assertNull(call_user_func(Functions::ARRAY_HEAD, array()));
     }
 
-    /** @testdox It should be possible to use a constant for Arrays\tail() as a callable */
-    public function testArrayTail(): void
+    /** @testdox It should be possible to use a constant for Arrays\last() as a callable */
+    public function testArrayLast(): void
     {
-        $this->assertEquals('2', call_user_func(Functions::ARRAY_TAIL, array( '1', '2' )));
-        $this->assertNull(call_user_func(Functions::ARRAY_TAIL, array()));
+        $this->assertEquals('2', call_user_func(Functions::ARRAY_LAST, array('1', '2')));
+        $this->assertNull(call_user_func(Functions::ARRAY_LAST, array()));
     }
 
     /** @testdox It should be possible to use a constant for Comparisons\isTrue() as a callable */
@@ -51,7 +51,7 @@ class FunctionConstantsTest extends TestCase
         $this->assertFalse(call_user_func(Functions::IS_TRUE, '1'));
 
         $this->assertFalse(call_user_func(Functions::IS_TRUE, array()));
-        $this->assertFalse(call_user_func(Functions::IS_TRUE, array( 1, 2, 3 )));
+        $this->assertFalse(call_user_func(Functions::IS_TRUE, array(1, 2, 3)));
 
         $this->assertFalse(call_user_func(Functions::IS_TRUE, null));
     }
@@ -91,7 +91,7 @@ class FunctionConstantsTest extends TestCase
         $this->assertFalse(call_user_func(Functions::IS_NUMBER, '1.1'));
 
         $this->assertFalse(call_user_func(Functions::IS_NUMBER, array()));
-        $this->assertFalse(call_user_func(Functions::IS_NUMBER, array( 1, 2, 3 )));
+        $this->assertFalse(call_user_func(Functions::IS_NUMBER, array(1, 2, 3)));
 
         $this->assertFalse(call_user_func(Functions::IS_NUMBER, null));
     }

--- a/_phpcs.xml.local
+++ b/_phpcs.xml.local
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<description>Use PSR12 Rules</description>
+
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Include the PSR12 Rules. -->
+	<rule ref="PSR12"></rule>
+
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<description>Use PSR12 Rules</description>
+
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Include the PSR12 Rules. -->
+	<rule ref="WordPress-Extra"></rule>
+
+
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,3 +13,4 @@ parameters:
         - '#Call to function is_array\(\) with mixed will always evaluate to false#'
         - '#should return Closure\(array\): array{array, array} but returns Closure\(array\): array#'
     reportUnmatchedIgnoredErrors: false
+    treatPhpDocTypesAsCertain: false

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -78,7 +78,18 @@ function pushTail(array $array): Closure
  */
 function head(array $array)
 {
-    return ! empty($array) ? array_values($array)[0] : null;
+    return !empty($array) ? array_values($array)[0] : null;
+}
+
+/**
+ * Gets the last value from an array.
+ *
+ * @param array<int|string, mixed> $array The array.
+ * @return mixed Will return the last value is array is not empty, else null.
+ */
+function last(array $array)
+{
+    return !empty($array) ? array_reverse($array, false)[0] : null;
 }
 
 /**
@@ -89,7 +100,14 @@ function head(array $array)
  */
 function tail(array $array)
 {
-    return ! empty($array) ? array_reverse($array, false)[0] : null;
+    // Return null if empty.
+    if (empty($array)) {
+        return null;
+    }
+
+    // Remove the first item from the array.
+    array_shift($array);
+    return $array;
 }
 
 
@@ -128,8 +146,8 @@ function zip(array $additional, $default = null): Closure
             array_keys($array),
             function ($carry, $key) use ($array, $additional, $default): array {
                 $carry[] = array(
-                    $array[ $key ],
-                    array_key_exists($key, $additional) ? $additional[ $key ] : $default,
+                    $array[$key],
+                    array_key_exists($key, $additional) ? $additional[$key] : $default,
                 );
                 return $carry;
             },
@@ -163,7 +181,7 @@ function arrayCompiler(array $inital = array()): Closure
         if ($value) {
             $inital[] = $value;
         }
-        return ! is_null($value) ? arrayCompiler($inital) : $inital;
+        return !is_null($value) ? arrayCompiler($inital) : $inital;
     };
 }
 
@@ -185,10 +203,10 @@ function arrayCompilerTyped(callable $validator, array $inital = array()): Closu
      * @return mixed[]|Closure
      */
     return function ($value = null) use ($validator, $inital) {
-        if (! is_null($value) && $validator($value)) {
+        if (!is_null($value) && $validator($value)) {
             $inital[] = $value;
         }
-        return ! is_null($value) ? arrayCompilerTyped($validator, $inital) : $inital;
+        return !is_null($value) ? arrayCompilerTyped($validator, $inital) : $inital;
     };
 }
 
@@ -301,7 +319,7 @@ function filterLast(callable $func): Closure
      * @return mixed|null The last element from the filtered array.
      */
     return function (array $array) use ($func) {
-        return tail(array_filter($array, $func));
+        return last(array_filter($array, $func));
     };
 }
 
@@ -366,10 +384,10 @@ function partition(callable $function): Closure
              */
             function ($carry, $element) use ($function): array {
                 $key             = (bool) $function($element) ? 1 : 0;
-                $carry[ $key ][] = $element;
+                $carry[$key][] = $element;
                 return $carry;
             },
-            array( array(), array() )
+            array(array(), array())
         );
     };
 }
@@ -462,7 +480,7 @@ function mapKey(callable $func): Closure
         return array_reduce(
             array_keys($array),
             function ($carry, $key) use ($func, $array) {
-                $carry[ $func($key) ] = $array[ $key ];
+                $carry[$func($key)] = $array[$key];
                 return $carry;
             },
             array()
@@ -601,7 +619,7 @@ function groupBy(callable $function): Closure
              * @return mixed[]
              */
             function ($carry, $item) use ($function): array {
-                $carry[ call_user_func($function, $item) ][] = $item;
+                $carry[call_user_func($function, $item)][] = $item;
                 return $carry;
             },
             array()
@@ -749,7 +767,7 @@ function toObject($object = null): Closure
     $object = $object ?? new stdClass();
 
     // Throws an exception if $object is not an object.
-    if (! is_object($object)) {
+    if (!is_object($object)) {
         throw new \InvalidArgumentException('Object must be an object.');
     }
 
@@ -760,7 +778,7 @@ function toObject($object = null): Closure
     return function (array $array) use ($object) {
         foreach ($array as $key => $value) {
             // If key is not a string or numerical, skip it.
-            if (! is_string($key) || is_numeric($key)) {
+            if (!is_string($key) || is_numeric($key)) {
                 continue;
             }
 
@@ -1156,7 +1174,7 @@ function takeLast(int $count = 1): Closure
      * @return mixed[]
      */
     return function (array $array) use ($count) {
-        return \array_slice($array, - $count);
+        return \array_slice($array, -$count);
     };
 }
 
@@ -1179,7 +1197,7 @@ function takeUntil(callable $conditional): Closure
             if (true === $conditional($value)) {
                 break;
             }
-            $carry[ $key ] = $value;
+            $carry[$key] = $value;
         }
         return $carry;
     };
@@ -1204,7 +1222,7 @@ function takeWhile(callable $conditional): Closure
             if (false === $conditional($value)) {
                 break;
             }
-            $carry[ $key ] = $value;
+            $carry[$key] = $value;
         }
         return $carry;
     };

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -122,7 +122,7 @@ function toString(?string $glue = null): Closure
 {
     /**
      * @param array<int|string, mixed> $array Array join
-     * @return string.
+     * @return string
      */
     return function (array $array) use ($glue): string {
         return $glue ? \join($glue, $array) : \join($array);

--- a/src/comparisons.php
+++ b/src/comparisons.php
@@ -46,7 +46,7 @@ function isEqualTo($a): Closure
      * @return bool
      */
     return function ($b) use ($a): bool {
-        if (! sameScalar($b, $a)) {
+        if (!sameScalar($b, $a)) {
             return false;
         }
 
@@ -84,7 +84,7 @@ function isNotEqualTo($a): Closure
      * @return bool
      */
     return function ($b) use ($a): bool {
-        return ! isEqualTo($a)($b);
+        return !isEqualTo($a)($b);
     };
 }
 
@@ -102,7 +102,7 @@ function isGreaterThan($a): Closure
      * @return bool
      */
     return function ($b) use ($a): bool {
-        return isEqualIn(array( 'integer', 'double' ))(gettype($b))
+        return isEqualIn(array('integer', 'double'))(gettype($b))
             ? $a < $b : false;
     };
 }
@@ -121,7 +121,7 @@ function isLessThan($a): Closure
      * @return bool
      */
     return function ($b) use ($a): bool {
-        return isEqualIn(array( 'integer', 'double' ))(gettype($b))
+        return isEqualIn(array('integer', 'double'))(gettype($b))
             ? $a > $b : false;
     };
 }
@@ -206,7 +206,7 @@ function isEqualIn(array $a): Closure
  */
 function notEmpty($value): bool
 {
-    return ! empty($value);
+    return !empty($value);
 }
 
 /**
@@ -298,7 +298,7 @@ function sameScalar(...$variables): bool
 function allTrue(bool ...$variables): bool
 {
     foreach ($variables as $value) {
-        if (! is_bool($value) || $value !== true) {
+        if ($value !== true) {
             return false;
         }
     }
@@ -314,7 +314,7 @@ function allTrue(bool ...$variables): bool
 function anyTrue(bool ...$variables): bool
 {
     foreach ($variables as $value) {
-        if (is_bool($value) && $value === true) {
+        if ($value === true) {
             return true;
         }
     }
@@ -389,6 +389,6 @@ function not(callable $callable): Closure
      * @return bool
      */
     return function ($value) use ($callable): bool {
-        return ! (bool) $callable($value);
+        return !(bool) $callable($value);
     };
 }

--- a/src/function-constants.php
+++ b/src/function-constants.php
@@ -63,9 +63,9 @@ class Functions
     public const ARRAY_HEAD = 'PinkCrab\FunctionConstructors\Arrays\head';
 
     /**
-     * Constants used for PinkCrab\FunctionConstructors\Arrays\tail(array $array):?mixed
+     * Constants used for PinkCrab\FunctionConstructors\Arrays\last(array $array):?mixed
      */
-    public const ARRAY_TAIL = 'PinkCrab\FunctionConstructors\Arrays\tail';
+    public const ARRAY_LAST = 'PinkCrab\FunctionConstructors\Arrays\last';
 
     ## String ##
 

--- a/src/general.php
+++ b/src/general.php
@@ -46,7 +46,7 @@ use PinkCrab\FunctionConstructors\Objects as Objects;
 function compose(callable ...$callables): Closure
 {
     /**
-     * @param mixed The value passed into the functions
+     * @param mixed $e The value passed into the functions
      * @return mixed The final result.
      */
     return function ($e) use ($callables) {
@@ -67,7 +67,7 @@ function compose(callable ...$callables): Closure
 function composeR(callable ...$callables): Closure
 {
     /**
-     * @param mixed The value passed into the functions
+     * @param mixed $e The value passed into the functions
      * @return mixed The final result.
      */
     return function ($e) use ($callables) {
@@ -88,12 +88,12 @@ function composeR(callable ...$callables): Closure
 function composeSafe(callable ...$callables): Closure
 {
     /**
-     * @param mixed The value passed into the functions
+     * @param mixed $e The value passed into the functions
      * @return mixed|null The final result or null.
      */
     return function ($e) use ($callables) {
         foreach ($callables as $callable) {
-            if (! is_null($e)) {
+            if (!is_null($e)) {
                 $e = $callable($e);
             }
         }
@@ -119,14 +119,14 @@ function composeTypeSafe(callable $validator, callable ...$callables): Closure
     return function ($e) use ($validator, $callables) {
         foreach ($callables as $callable) {
             // If invalid, abort and return null
-            if (! $validator($e)) {
+            if (!$validator($e)) {
                 return null;
             }
             // Run through callable.
             $e = $callable($e);
 
             // Check results and bail if invalid type.
-            if (! $validator($e)) {
+            if (!$validator($e)) {
                 return null;
             }
         }
@@ -174,7 +174,7 @@ function getProperty(string $property): Closure
      */
     return function ($data) use ($property) {
         if (is_array($data)) {
-            return array_key_exists($property, $data) ? $data[ $property ] : null;
+            return array_key_exists($property, $data) ? $data[$property] : null;
         } elseif (is_object($data)) {
             return property_exists($data, $property) ? $data->{$property} : null;
         } else {
@@ -265,13 +265,13 @@ function propertyEquals(string $property, $value): Closure
  * Only works for public or dynamic properties.
  *
  * @param array<string,mixed>|ArrayObject<string,mixed>|object $store
-     * @param string $property The property key.
+ * @param string $property The property key.
  * @return Closure(mixed):(array<string,mixed>|ArrayObject<string,mixed>|object)
  */
 function setProperty($store, string $property): Closure
 {
     // If passed store is not an array or object, throw exception.
-    if (! isArrayAccess($store) && ! is_object($store)) {
+    if (!isArrayAccess($store) && !is_object($store)) {
         throw new TypeError('Only objects or arrays can be constructed using setProperty.');
     }
 
@@ -282,7 +282,7 @@ function setProperty($store, string $property): Closure
     return function ($value) use ($store, $property) {
         if (isArrayAccess($store)) {
             /** @phpstan-ignore-next-line */
-            $store[ $property ] = $value;
+            $store[$property] = $value;
         } else {
             $store->{$property} = $value;
         }
@@ -306,7 +306,7 @@ function encodeProperty(string $key, callable $value): Closure
      * @return array
      */
     return function ($data) use ($key, $value): array {
-        return array( $key => $value($data) );
+        return array($key => $value($data));
     };
 }
 


### PR DESCRIPTION
Corrects the issue where `Arrays\tail()` is more `last()` than actual tail()

Updates `Arrays\tail()` to return the array with the head removed
Adds in `Arrays\last()` to get the last item from an array and work as `tail()` did.