### PR TITLE
Feature/gh79 arrays append prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,10 +568,13 @@ If you would like to contribute to this project, please feel to fork the project
   * `Strings\compare()` 
   * `Strings\countChars()` now has mode constants.
   * `Arrays\last()` will return the last element of an array.
+  * `Arrays\append()` will append a value to the end of an array.
+  * `Arrays\prepend()` will prepend a value to the start of an array.
   * **Breaking Changes**
   * `Strings\decimalNumber()` has been deprecated in favour of `Strings\digit()`
   * `Strings\similarAsBase()` and `Strings\similarAsComparison()` have been deprecated in favour of `Strings\similar()`
   * `Arrays\tail()` now works as expected, returning the array without the first element.
+  * `Arrays\pushHead()` and `Arrays\pushTail()` have been deprecated in favour of `Arrays\prepend()` and `Arrays\append()`
 
 
 * 0.2.0 - 

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -74,35 +74,6 @@ class ArrayFunctionTests extends TestCase
         $this->assertEquals(6, $new[5]);
     }
 
-    public function testCanPushToHead(): void
-    {
-        $pushToHead = Arr\pushHead(array(3, 4, 5, 6));
-        $added2     = $pushToHead(2);
-        $this->assertEquals(2, $added2[0]);
-
-        $pushToHead = Arr\pushHead($added2);
-        $added1     = $pushToHead(1);
-        $this->assertEquals(1, $added1[0]);
-
-        // As curried.
-        $curried = Arr\pushHead(array(3, 4, 5, 6))(2);
-        $this->assertEquals(2, $curried[0]);
-    }
-
-    public function testCanPushToTail(): void
-    {
-        $pushToTail = Arr\pushTail(array(1, 2, 3, 4));
-        $added2     = $pushToTail(5);
-        $this->assertEquals(5, $added2[4]);
-
-        $pushToTail = Arr\pushTail($added2);
-        $added1     = $pushToTail(6);
-        $this->assertEquals(6, $added1[5]);
-
-        // As curried.
-        $curried = Arr\pushTail(array(1, 2, 3, 4))(5);
-        $this->assertEquals(5, $curried[4]);
-    }
 
     public function testCanUseTail()
     {

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -42,6 +42,38 @@ class ArrayFunctionTests extends TestCase
         FunctionsLoader::include();
     }
 
+    /** @testdox It should be possible to prepend and item to an array. */
+    public function testCanPrependToArray(): void
+    {
+        $array = array(1, 2, 3, 4, 5);
+
+        $prepend0 = Arr\prepend(0);
+        $new = $prepend0($array);
+
+        $this->assertEquals(0, $new[0]);
+        $this->assertEquals(1, $new[1]);
+        $this->assertEquals(2, $new[2]);
+        $this->assertEquals(3, $new[3]);
+        $this->assertEquals(4, $new[4]);
+        $this->assertEquals(5, $new[5]);
+    }
+
+    /** @testdox It should be possible to append and item to an array. */
+    public function testCanAppendToArray(): void
+    {
+        $array = array(1, 2, 3, 4, 5);
+
+        $append6 = Arr\append(6);
+        $new = $append6($array);
+
+        $this->assertEquals(1, $new[0]);
+        $this->assertEquals(2, $new[1]);
+        $this->assertEquals(3, $new[2]);
+        $this->assertEquals(4, $new[3]);
+        $this->assertEquals(5, $new[4]);
+        $this->assertEquals(6, $new[5]);
+    }
+
     public function testCanPushToHead(): void
     {
         $pushToHead = Arr\pushHead(array(3, 4, 5, 6));

--- a/Tests/test-deprecated.php
+++ b/Tests/test-deprecated.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PinkCrab\FunctionConstructors\Arrays as Arr;
 use PinkCrab\FunctionConstructors\Strings as Str;
 use PinkCrab\FunctionConstructors\FunctionsLoader;
 
@@ -163,5 +164,65 @@ class DeprecatedTest extends TestCase
     {
         $compareTheBaseAsChars = @Str\similarAsBase('BASE');
         $this->assertEquals(4, $compareTheBaseAsChars('THE BASE'));
+    }
+
+    /** @testdox Calling pushHead should throw a deprecation notice */
+    public function testPushHead(): void
+    {
+        // If using PHPUnit 9, we need to use the expectDeprecation() method
+        if (version_compare(\PHPUnit\Runner\Version::id(), '9.0.0', '>=')) {
+            $this->expectDeprecation();
+        } else {
+            $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+        }
+        $pushToHead = Arr\pushHead(array(3, 4, 5, 6));
+        $added2     = $pushToHead(2);
+        $this->assertEquals(2, $added2[0]);
+    }
+
+
+    /** @testdox Calling pushTail should throw a deprecation notice */
+    public function testPushTail(): void
+    {
+        // If using PHPUnit 9, we need to use the expectDeprecation() method
+        if (version_compare(\PHPUnit\Runner\Version::id(), '9.0.0', '>=')) {
+            $this->expectDeprecation();
+        } else {
+            $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+        }
+        $pushToHead = Arr\pushTail(array(3, 4, 5, 6));
+        $added2     = $pushToHead(7);
+        $this->assertEquals(7, $added2[4]);
+    }
+
+
+    public function testCanPushToHead(): void
+    {
+        $pushToHead = @Arr\pushHead(array(3, 4, 5, 6));
+        $added2     = $pushToHead(2);
+        $this->assertEquals(2, $added2[0]);
+
+        $pushToHead = @Arr\pushHead($added2);
+        $added1     = $pushToHead(1);
+        $this->assertEquals(1, $added1[0]);
+
+        // As curried.
+        $curried = @Arr\pushHead(array(3, 4, 5, 6))(2);
+        $this->assertEquals(2, $curried[0]);
+    }
+
+    public function testCanPushToTail(): void
+    {
+        $pushToTail = @Arr\pushTail(array(1, 2, 3, 4));
+        $added2     = $pushToTail(5);
+        $this->assertEquals(5, $added2[4]);
+
+        $pushToTail = @Arr\pushTail($added2);
+        $added1     = $pushToTail(6);
+        $this->assertEquals(6, $added1[5]);
+
+        // As curried.
+        $curried = @Arr\pushTail(array(1, 2, 3, 4))(5);
+        $this->assertEquals(5, $curried[4]);
     }
 }

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -75,9 +75,12 @@ function prepend($value): Closure
  *
  * @param array<int|string, mixed> $array
  * @return Closure(mixed):array<int|string, mixed>
+ * @deprecated 0.3.0 Use prepend() instead.
  */
 function pushHead(array $array): Closure
 {
+
+    trigger_error('Deprecated function called. This function will be removed in later versions.', E_USER_DEPRECATED);
     /**
      * @param mixed $value Adds value start of array.
      * @return array New array with value on head.
@@ -93,9 +96,11 @@ function pushHead(array $array): Closure
  *
  * @param array<int|string, mixed> $array
  * @return Closure(mixed):array<int|string, mixed>
+ * @deprecated 0.3.0 Use append() instead.
  */
 function pushTail(array $array): Closure
 {
+    trigger_error('Deprecated function called. This function will be removed in later versions.', E_USER_DEPRECATED);
     /**
      * @param mixed $value Adds value end of array.
      * @return array<int|string, mixed> New array with value on tail.

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -79,7 +79,6 @@ function prepend($value): Closure
  */
 function pushHead(array $array): Closure
 {
-
     trigger_error('Deprecated function called. This function will be removed in later versions.', E_USER_DEPRECATED);
     /**
      * @param mixed $value Adds value start of array.

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -35,6 +35,42 @@ use stdClass;
 use PinkCrab\FunctionConstructors\Comparisons as Comp;
 
 /**
+ * Returns a Closure for appending a value to an array.
+ *
+ * @param mixed $value
+ * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ */
+function append($value): Closure
+{
+    /**
+     * @param array<int|string, mixed> $array
+     * @return array<int|string, mixed>
+     */
+    return function (array $array) use ($value): array {
+        $array[] = $value;
+        return $array;
+    };
+}
+
+/**
+ * Returns a Closure for prepending a value to an array.
+ *
+ * @param mixed $value
+ * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ */
+function prepend($value): Closure
+{
+    /**
+     * @param array<int|string, mixed> $array
+     * @return array<int|string, mixed>
+     */
+    return function (array $array) use ($value): array {
+        array_unshift($array, $value);
+        return $array;
+    };
+}
+
+/**
  * Returns a Closure for pushing a value to the head of an array
  *
  * @param array<int|string, mixed> $array


### PR DESCRIPTION
Both `Arrays\pushHead()` and `Arrays\pushTail()` has been deprecated
`Arrays\append()` and `Arrays\prepend()` has been added