### PR TITLE
Feature/add sideeffect function

### DIFF
--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -376,8 +376,8 @@ class GeneralFunctionTest extends TestCase
         $this->assertTrue($hasFoo(array( 'foo' => 'bar' )));
         $this->assertFalse($hasFoo(array( 'bar' => 'foo' )));
         // Obejct
-        $this->assertTrue($hasFoo((object) array( 'foo' => 'bar')));
-        $this->assertFalse($hasFoo((object) array( 'bar' => 'foo')));
+        $this->assertTrue($hasFoo((object) array( 'foo' => 'bar' )));
+        $this->assertFalse($hasFoo((object) array( 'bar' => 'foo' )));
         // Invalid
         $this->assertFalse($hasFoo('not array or obejct'));
     }

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -376,8 +376,8 @@ class GeneralFunctionTest extends TestCase
         $this->assertTrue($hasFoo(array( 'foo' => 'bar' )));
         $this->assertFalse($hasFoo(array( 'bar' => 'foo' )));
         // Obejct
-        $this->assertTrue($hasFoo((object) array( 'foo' => 'bar' )));
-        $this->assertFalse($hasFoo((object) array( 'bar' => 'foo' )));
+        $this->assertTrue($hasFoo((object) array( 'foo' => 'bar')));
+        $this->assertFalse($hasFoo((object) array( 'bar' => 'foo')));
         // Invalid
         $this->assertFalse($hasFoo('not array or obejct'));
     }
@@ -394,7 +394,7 @@ class GeneralFunctionTest extends TestCase
     {
         // Array
         $setName = Func\setProperty(array('id' => 1), 'name');
-        $this->assertEquals(array('id' => 1, 'name' => 'bar'), $setName('bar'));
+        $this->assertEquals(array( 'id' => 1,'name' => 'bar' ), $setName('bar'));
 
         // Object with ArrayAccess
         $instance = ObjectFactory::arrayAccess();
@@ -435,8 +435,8 @@ class GeneralFunctionTest extends TestCase
         );
 
         $this->assertEquals(
-            array('id' => 1, 'name' => 'foo'),
-            $encoder(array('userId' => 1, 'userName' => 'foo'))
+            array( 'id' => 1, 'name' => 'foo' ),
+            $encoder(array( 'userId' => 1, 'userName' => 'foo' ))
         );
     }
 
@@ -452,7 +452,7 @@ class GeneralFunctionTest extends TestCase
             Func\encodeProperty('name', Func\getProperty('userName'))
         );
 
-        $new = $encoder(array('userId' => 1, 'userName' => 'foo'));
+        $new = $encoder(array( 'userId' => 1, 'userName' => 'foo' ));
 
         $this->assertEquals(1, $new->id);
         $this->assertEquals('foo', $new->name);
@@ -470,7 +470,7 @@ class GeneralFunctionTest extends TestCase
             Func\encodeProperty('name', Func\getProperty('userName'))
         );
 
-        $new = $encoder((object) array('userId' => 1, 'userName' => 'foo'));
+        $new = $encoder((object) array( 'userId' => 1, 'userName' => 'foo' ));
 
         $this->assertEquals(1, $new['id']);
         $this->assertEquals('foo', $new['name']);
@@ -488,7 +488,7 @@ class GeneralFunctionTest extends TestCase
             Func\encodeProperty('name', Func\getProperty('userName'))
         );
 
-        $new = $encoder((object) array('userId' => 1, 'userName' => 'foo'));
+        $new = $encoder((object) array( 'userId' => 1, 'userName' => 'foo' ));
 
         $this->assertEquals(1, $new['id']);
         $this->assertEquals('foo', $new['name']);
@@ -497,7 +497,7 @@ class GeneralFunctionTest extends TestCase
     /** @testdox Attempting to set a recordEncoder using a numerical index, willthrow a TyprError */
     public function testRecordEncoderThrowsTypeError(): void
     {
-        $this->expectexception(typeerror::class);
+        $this->expectException(typeerror::class);
 
         $encoder = func\recordencoder(new stdclass());
         $encoder = $encoder(func\encodeproperty('0', func\getproperty('userid')));

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -497,7 +497,7 @@ class GeneralFunctionTest extends TestCase
     /** @testdox Attempting to set a recordEncoder using a numerical index, willthrow a TyprError */
     public function testRecordEncoderThrowsTypeError(): void
     {
-        $this->expectException(typeerror::class);
+        $this->expectException(TypeError::class);
 
         $encoder = func\recordencoder(new stdclass());
         $encoder = $encoder(func\encodeproperty('0', func\getproperty('userid')));

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -16,6 +16,7 @@ use PinkCrab\FunctionConstructors\Numbers as Num;
 use PinkCrab\FunctionConstructors\Strings as Str;
 use PinkCrab\FunctionConstructors\FunctionsLoader;
 use PinkCrab\FunctionConstructors\GeneralFunctions as Func;
+use PinkCrab\FunctionConstructors\Experimental as Exp;
 use PinkCrab\FunctionConstructors\Tests\Providers\ObjectFactory;
 
 class ToArrayFixtureClass
@@ -86,7 +87,8 @@ class GeneralFunctionTest extends TestCase
 
     public function testFunctionCompseSafeHandlesNull(): void
     {
-        $reutrnsNull = function ($e) {
+        $reutrnsNull = function ($e)
+        {
             return null;
         };
 
@@ -120,7 +122,8 @@ class GeneralFunctionTest extends TestCase
     public function testTypeSafeFunctionalComposerReturnsNull(): void
     {
         $function = Func\composeTypeSafe(
-            function ($e) {
+            function ($e)
+            {
                 return false;
             },
             Str\replaceWith('3344', '*\/*'),
@@ -191,7 +194,7 @@ class GeneralFunctionTest extends TestCase
                 'id'      => 123,
                 'title'   => 'Lorem ipsum dolor',
                 'content' => 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Similique iste voluptatum sequi. Officia dignissimos minus ipsum odit, facilis voluptatibus veniam enim molestiae ipsam quae temporibus porro necessitatibus quia non mollitia!',
-                'date'    => ( new DateTime() )->format('d/m/yy H:m'),
+                'date'    => (new DateTime())->format('d/m/yy H:m'),
                 'author'  => (object) array(
                     'userName'    => 'someUser12',
                     'displayName' => 'Sam Smith',
@@ -205,7 +208,7 @@ class GeneralFunctionTest extends TestCase
                         'userName'    => 'someUser2',
                         'displayName' => 'Jane Jameson',
                         'comment'     => 'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Hic, illo tempore repudiandae quos vero, vitae aut ullam tenetur officiis accusantium dolor animi ipsa omnis impedit, saepe est harum quisquam sit.',
-                        'date'        => ( new DateTime('yesterday') )->format('d/m/yy H:m'),
+                        'date'        => (new DateTime('yesterday'))->format('d/m/yy H:m'),
                     ),
                 ),
                 (object) array(
@@ -214,7 +217,7 @@ class GeneralFunctionTest extends TestCase
                         'userName'    => 'someUser22',
                         'displayName' => 'Barry Burton',
                         'comment'     => 'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Hic, illo tempore repudiandae quos vero, vitae aut ullam tenetur officiis accusantium dolor animi ipsa omnis impedit, saepe est harum quisquam sit.',
-                        'date'        => ( new DateTime('yesterday') )->format('d/m/yy H:m'),
+                        'date'        => (new DateTime('yesterday'))->format('d/m/yy H:m'),
                     ),
                 ),
             ),
@@ -312,7 +315,7 @@ class GeneralFunctionTest extends TestCase
         // Check it returns blank array if any other value passed.
         $this->assertEmpty($toArrray(false));
         $this->assertEmpty($toArrray(null));
-        $this->assertEmpty($toArrray(array( 1, 2, 3, 4 )));
+        $this->assertEmpty($toArrray(array(1, 2, 3, 4)));
         $this->assertEmpty($toArrray(1));
         $this->assertEmpty($toArrray(2.5));
         $this->assertEmpty($toArrray('STRING'));
@@ -322,10 +325,12 @@ class GeneralFunctionTest extends TestCase
     public function testIfThen(): void
     {
         $ifStringMakeTree = Func\ifThen(
-            function ($e) {
+            function ($e)
+            {
                 return $e === 'string';
             },
-            function ($e) {
+            function ($e)
+            {
                 return 'tree';
             }
         );
@@ -338,13 +343,16 @@ class GeneralFunctionTest extends TestCase
     public function testIfElse(): void
     {
         $ifStringMakeTree = Func\ifElse(
-            function ($e) {
+            function ($e)
+            {
                 return $e === 'string';
             },
-            function ($e) {
+            function ($e)
+            {
                 return 'tree';
             },
-            function ($e) {
+            function ($e)
+            {
                 return 'NOTSTRING';
             }
         );
@@ -359,11 +367,11 @@ class GeneralFunctionTest extends TestCase
     {
         $getFoo = Func\getProperty('foo');
         // Array
-        $this->assertEquals('bar', $getFoo(array( 'foo' => 'bar' )));
-        $this->assertNull($getFoo(array( 'bar' => 'foo' )));
+        $this->assertEquals('bar', $getFoo(array('foo' => 'bar')));
+        $this->assertNull($getFoo(array('bar' => 'foo')));
         // Obejct
-        $this->assertEquals('bar', $getFoo((object) array( 'foo' => 'bar' )));
-        $this->assertNull($getFoo((object) array( 'bar' => 'foo' )));
+        $this->assertEquals('bar', $getFoo((object) array('foo' => 'bar')));
+        $this->assertNull($getFoo((object) array('bar' => 'foo')));
         // Invalid
         $this->assertNull($getFoo('not array or obejct'));
     }
@@ -373,11 +381,11 @@ class GeneralFunctionTest extends TestCase
     {
         $hasFoo = Func\hasProperty('foo');
         // Array
-        $this->assertTrue($hasFoo(array( 'foo' => 'bar' )));
-        $this->assertFalse($hasFoo(array( 'bar' => 'foo' )));
+        $this->assertTrue($hasFoo(array('foo' => 'bar')));
+        $this->assertFalse($hasFoo(array('bar' => 'foo')));
         // Obejct
-        $this->assertTrue($hasFoo((object) array( 'foo' => 'bar' )));
-        $this->assertFalse($hasFoo((object) array( 'bar' => 'foo' )));
+        $this->assertTrue($hasFoo((object) array('foo' => 'bar')));
+        $this->assertFalse($hasFoo((object) array('bar' => 'foo')));
         // Invalid
         $this->assertFalse($hasFoo('not array or obejct'));
     }
@@ -394,7 +402,7 @@ class GeneralFunctionTest extends TestCase
     {
         // Array
         $setName = Func\setProperty(array('id' => 1), 'name');
-        $this->assertEquals(array( 'id'=>1,'name' => 'bar' ), $setName('bar'));
+        $this->assertEquals(array('id' => 1, 'name' => 'bar'), $setName('bar'));
 
         // Object with ArrayAccess
         $instance = ObjectFactory::arrayAccess();
@@ -409,7 +417,7 @@ class GeneralFunctionTest extends TestCase
         $this->assertEquals('bar', $withBar['name']);
 
         // ArrayObject with ObjectAccess
-        $ObjectAccess = new ArrayObject((object)['id'=> 12, 'name' => null], ArrayObject::STD_PROP_LIST);
+        $ObjectAccess = new ArrayObject((object)['id' => 12, 'name' => null], ArrayObject::STD_PROP_LIST);
         $setName = Func\setProperty($ObjectAccess, 'name');
         $ObjectAccess = $setName('bar');
         $this->assertEquals('bar', $ObjectAccess['name']);
@@ -435,8 +443,8 @@ class GeneralFunctionTest extends TestCase
         );
 
         $this->assertEquals(
-            array( 'id' => 1, 'name' => 'foo' ),
-            $encoder(array( 'userId' => 1, 'userName' => 'foo' ))
+            array('id' => 1, 'name' => 'foo'),
+            $encoder(array('userId' => 1, 'userName' => 'foo'))
         );
     }
 
@@ -452,7 +460,7 @@ class GeneralFunctionTest extends TestCase
             Func\encodeProperty('name', Func\getProperty('userName'))
         );
 
-        $new = $encoder(array( 'userId' => 1, 'userName' => 'foo' ));
+        $new = $encoder(array('userId' => 1, 'userName' => 'foo'));
 
         $this->assertEquals(1, $new->id);
         $this->assertEquals('foo', $new->name);
@@ -470,7 +478,7 @@ class GeneralFunctionTest extends TestCase
             Func\encodeProperty('name', Func\getProperty('userName'))
         );
 
-        $new = $encoder((object) array( 'userId' => 1, 'userName' => 'foo' ));
+        $new = $encoder((object) array('userId' => 1, 'userName' => 'foo'));
 
         $this->assertEquals(1, $new['id']);
         $this->assertEquals('foo', $new['name']);
@@ -488,7 +496,7 @@ class GeneralFunctionTest extends TestCase
             Func\encodeProperty('name', Func\getProperty('userName'))
         );
 
-        $new = $encoder((object) array( 'userId' => 1, 'userName' => 'foo' ));
+        $new = $encoder((object) array('userId' => 1, 'userName' => 'foo'));
 
         $this->assertEquals(1, $new['id']);
         $this->assertEquals('foo', $new['name']);
@@ -497,10 +505,43 @@ class GeneralFunctionTest extends TestCase
     /** @testdox Attempting to set a recordEncoder using a numerical index, willthrow a TyprError */
     public function testRecordEncoderThrowsTypeError(): void
     {
-        $this->expectException(TypeError::class);
+        $this->expectexception(typeerror::class);
 
-        $encoder = Func\recordEncoder(new stdClass());
-        $encoder = $encoder(Func\encodeProperty('0', Func\getProperty('userId')));
-        $encoder(array( 'userId' => 1, 'userName' => 'foo' ));
+        $encoder = func\recordencoder(new stdclass());
+        $encoder = $encoder(func\encodeproperty('0', func\getproperty('userid')));
+        $encoder(array('userid' => 1, 'username' => 'foo'));
     }
+
+    /** @testdox it should be possible to send an anonymous that produces a side effect. */
+    public function testCanUseSideEffectWithAnonymousFunction()
+    {
+        $sideEffect = Func\sideEffect(function ($e)
+        {
+            var_dump($e);
+        });
+
+        $this->assertEquals('bar', $sideEffect('bar'));
+        $this->assertEquals(1, $sideEffect(1));
+        $this->assertEquals(2.5, $sideEffect(2.5));
+        $this->assertEquals(array(1, 2, 3), $sideEffect(array(1, 2, 3)));
+    }
+
+    /** @testdox it should be possible to send a built in function that produces a side effect. */
+    public function testCanUseSideEffectWithBuiltInFunction()
+    {
+        $sideEffect = Func\sideEffect('print_r');
+
+        $this->assertEquals('bar', $sideEffect('bar'));
+        $this->assertEquals(1, $sideEffect(1));
+        $this->assertEquals(2.5, $sideEffect(2.5));
+        $this->assertEquals(array(1, 2, 3), $sideEffect(array(1, 2, 3)));
+    }
+
+    public function testSideEffectThrowsTypeError()
+    {
+        $this->expectException(TypeError::class);
+        $sideEffect = Func\sideEffect(123);
+        $sideEffect('bar');
+    }
+
 }

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -499,9 +499,9 @@ class GeneralFunctionTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        $encoder = Func\recordencoder(new stdclass());
-        $encoder = $encoder(Func\encodeproperty('0', Func\getproperty('userid')));
-        $encoder(array('userid' => 1, 'username' => 'foo'));
+        $encoder = Func\recordEncoder(new stdclass());
+        $encoder = $encoder(Func\encodeProperty('0', Func\getProperty('userid')));
+        $encoder(array( 'userid' => 1, 'username' => 'foo' ));
     }
 
     /** @testdox it should be possible to send an anonymous that produces a side effect. */

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -499,8 +499,8 @@ class GeneralFunctionTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        $encoder = func\recordencoder(new stdclass());
-        $encoder = $encoder(func\encodeproperty('0', func\getproperty('userid')));
+        $encoder = Func\recordencoder(new stdclass());
+        $encoder = $encoder(Func\encodeproperty('0', Func\getproperty('userid')));
         $encoder(array('userid' => 1, 'username' => 'foo'));
     }
 

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -16,7 +16,6 @@ use PinkCrab\FunctionConstructors\Numbers as Num;
 use PinkCrab\FunctionConstructors\Strings as Str;
 use PinkCrab\FunctionConstructors\FunctionsLoader;
 use PinkCrab\FunctionConstructors\GeneralFunctions as Func;
-use PinkCrab\FunctionConstructors\Experimental as Exp;
 use PinkCrab\FunctionConstructors\Tests\Providers\ObjectFactory;
 
 class ToArrayFixtureClass
@@ -87,8 +86,7 @@ class GeneralFunctionTest extends TestCase
 
     public function testFunctionCompseSafeHandlesNull(): void
     {
-        $reutrnsNull = function ($e)
-        {
+        $reutrnsNull = function ($e) {
             return null;
         };
 
@@ -122,8 +120,7 @@ class GeneralFunctionTest extends TestCase
     public function testTypeSafeFunctionalComposerReturnsNull(): void
     {
         $function = Func\composeTypeSafe(
-            function ($e)
-            {
+            function ($e) {
                 return false;
             },
             Str\replaceWith('3344', '*\/*'),
@@ -194,7 +191,7 @@ class GeneralFunctionTest extends TestCase
                 'id'      => 123,
                 'title'   => 'Lorem ipsum dolor',
                 'content' => 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Similique iste voluptatum sequi. Officia dignissimos minus ipsum odit, facilis voluptatibus veniam enim molestiae ipsam quae temporibus porro necessitatibus quia non mollitia!',
-                'date'    => (new DateTime())->format('d/m/yy H:m'),
+                'date'    => ( new DateTime() )->format('d/m/yy H:m'),
                 'author'  => (object) array(
                     'userName'    => 'someUser12',
                     'displayName' => 'Sam Smith',
@@ -208,7 +205,7 @@ class GeneralFunctionTest extends TestCase
                         'userName'    => 'someUser2',
                         'displayName' => 'Jane Jameson',
                         'comment'     => 'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Hic, illo tempore repudiandae quos vero, vitae aut ullam tenetur officiis accusantium dolor animi ipsa omnis impedit, saepe est harum quisquam sit.',
-                        'date'        => (new DateTime('yesterday'))->format('d/m/yy H:m'),
+                        'date'        => ( new DateTime('yesterday') )->format('d/m/yy H:m'),
                     ),
                 ),
                 (object) array(
@@ -217,7 +214,7 @@ class GeneralFunctionTest extends TestCase
                         'userName'    => 'someUser22',
                         'displayName' => 'Barry Burton',
                         'comment'     => 'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Hic, illo tempore repudiandae quos vero, vitae aut ullam tenetur officiis accusantium dolor animi ipsa omnis impedit, saepe est harum quisquam sit.',
-                        'date'        => (new DateTime('yesterday'))->format('d/m/yy H:m'),
+                        'date'        => ( new DateTime('yesterday') )->format('d/m/yy H:m'),
                     ),
                 ),
             ),
@@ -315,7 +312,7 @@ class GeneralFunctionTest extends TestCase
         // Check it returns blank array if any other value passed.
         $this->assertEmpty($toArrray(false));
         $this->assertEmpty($toArrray(null));
-        $this->assertEmpty($toArrray(array(1, 2, 3, 4)));
+        $this->assertEmpty($toArrray(array( 1, 2, 3, 4 )));
         $this->assertEmpty($toArrray(1));
         $this->assertEmpty($toArrray(2.5));
         $this->assertEmpty($toArrray('STRING'));
@@ -325,12 +322,10 @@ class GeneralFunctionTest extends TestCase
     public function testIfThen(): void
     {
         $ifStringMakeTree = Func\ifThen(
-            function ($e)
-            {
+            function ($e) {
                 return $e === 'string';
             },
-            function ($e)
-            {
+            function ($e) {
                 return 'tree';
             }
         );
@@ -343,16 +338,13 @@ class GeneralFunctionTest extends TestCase
     public function testIfElse(): void
     {
         $ifStringMakeTree = Func\ifElse(
-            function ($e)
-            {
+            function ($e) {
                 return $e === 'string';
             },
-            function ($e)
-            {
+            function ($e) {
                 return 'tree';
             },
-            function ($e)
-            {
+            function ($e) {
                 return 'NOTSTRING';
             }
         );
@@ -367,11 +359,11 @@ class GeneralFunctionTest extends TestCase
     {
         $getFoo = Func\getProperty('foo');
         // Array
-        $this->assertEquals('bar', $getFoo(array('foo' => 'bar')));
-        $this->assertNull($getFoo(array('bar' => 'foo')));
+        $this->assertEquals('bar', $getFoo(array( 'foo' => 'bar' )));
+        $this->assertNull($getFoo(array( 'bar' => 'foo' )));
         // Obejct
-        $this->assertEquals('bar', $getFoo((object) array('foo' => 'bar')));
-        $this->assertNull($getFoo((object) array('bar' => 'foo')));
+        $this->assertEquals('bar', $getFoo((object) array( 'foo' => 'bar' )));
+        $this->assertNull($getFoo((object) array( 'bar' => 'foo' )));
         // Invalid
         $this->assertNull($getFoo('not array or obejct'));
     }
@@ -381,11 +373,11 @@ class GeneralFunctionTest extends TestCase
     {
         $hasFoo = Func\hasProperty('foo');
         // Array
-        $this->assertTrue($hasFoo(array('foo' => 'bar')));
-        $this->assertFalse($hasFoo(array('bar' => 'foo')));
+        $this->assertTrue($hasFoo(array( 'foo' => 'bar' )));
+        $this->assertFalse($hasFoo(array( 'bar' => 'foo' )));
         // Obejct
-        $this->assertTrue($hasFoo((object) array('foo' => 'bar')));
-        $this->assertFalse($hasFoo((object) array('bar' => 'foo')));
+        $this->assertTrue($hasFoo((object) array( 'foo' => 'bar' )));
+        $this->assertFalse($hasFoo((object) array( 'bar' => 'foo' )));
         // Invalid
         $this->assertFalse($hasFoo('not array or obejct'));
     }

--- a/Tests/test-general-functions.php
+++ b/Tests/test-general-functions.php
@@ -499,9 +499,9 @@ class GeneralFunctionTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        $encoder = Func\recordEncoder(new stdclass());
-        $encoder = $encoder(Func\encodeProperty('0', Func\getProperty('userid')));
-        $encoder(array( 'userid' => 1, 'username' => 'foo' ));
+        $encoder = Func\recordEncoder(new stdClass());
+        $encoder = $encoder(Func\encodeProperty('0', Func\getProperty('userId')));
+        $encoder(array( 'userId' => 1, 'userName' => 'foo' ));
     }
 
     /** @testdox it should be possible to send an anonymous that produces a side effect. */

--- a/src/general.php
+++ b/src/general.php
@@ -436,3 +436,26 @@ function ifElse(callable $condition, callable $then, callable $else): Closure
             : $else($value);
     };
 }
+/**
+ * Creates a side effect interceptor function that executes a given interceptor without modifying the input value.
+ * 
+ * @param string|Closure $interceptor A string function name or a callable to be executed as a side effect.
+ * @return Closure A function that calls the interceptor and returns the original input value.
+ * @throws \InvalidArgumentException If the interceptor is not a string or callable.
+ */
+function sideEffect(string|Closure $interceptor): Closure
+{
+    if (is_string($interceptor)) {
+        return function ($value) use ($interceptor): mixed {
+            call_user_func($interceptor, $value);
+            return $value;
+        };
+    } else if (is_callable($interceptor)) {
+        return function ($value) use ($interceptor): mixed {
+            $interceptor($value);
+            return $value;
+        };
+    } else {
+        throw new \InvalidArgumentException('Interceptor must be a string or callable');
+    }
+}

--- a/src/general.php
+++ b/src/general.php
@@ -444,7 +444,7 @@ function ifElse(callable $condition, callable $then, callable $else): Closure
  * @return Closure A function that calls the interceptor and returns the original input value.
  * @throws \InvalidArgumentException If the interceptor is not a string or callable.
  */
-function sideEffect(string|Closure $interceptor): Closure
+function sideEffect($interceptor): Closure
 {
     if (is_string($interceptor)) {
         return function ($value) use ($interceptor): mixed {

--- a/src/general.php
+++ b/src/general.php
@@ -447,12 +447,12 @@ function ifElse(callable $condition, callable $then, callable $else): Closure
 function sideEffect($interceptor): Closure
 {
     if (is_string($interceptor)) {
-        return function ($value) use ($interceptor): Closure {
+        return function ($value) use ($interceptor) {
             call_user_func($interceptor, $value);
             return $value;
         };
     } else if (is_callable($interceptor)) {
-        return function ($value) use ($interceptor): Closure {
+        return function ($value) use ($interceptor) {
             $interceptor($value);
             return $value;
         };

--- a/src/general.php
+++ b/src/general.php
@@ -436,6 +436,7 @@ function ifElse(callable $condition, callable $then, callable $else): Closure
             : $else($value);
     };
 }
+
 /**
  * Creates a side effect interceptor function that executes a given interceptor without modifying the input value.
  * 

--- a/src/general.php
+++ b/src/general.php
@@ -442,21 +442,21 @@ function ifElse(callable $condition, callable $then, callable $else): Closure
  * 
  * @param string|Closure $interceptor A string function name or a callable to be executed as a side effect.
  * @return Closure A function that calls the interceptor and returns the original input value.
- * @throws \InvalidArgumentException If the interceptor is not a string or callable.
+ * @throws \TypeError If the interceptor is not a string or callable.
  */
 function sideEffect($interceptor): Closure
 {
     if (is_string($interceptor)) {
-        return function ($value) use ($interceptor): mixed {
+        return function ($value) use ($interceptor): Closure {
             call_user_func($interceptor, $value);
             return $value;
         };
     } else if (is_callable($interceptor)) {
-        return function ($value) use ($interceptor): mixed {
+        return function ($value) use ($interceptor): Closure {
             $interceptor($value);
             return $value;
         };
     } else {
-        throw new \InvalidArgumentException('Interceptor must be a string or callable');
+        throw new \TypeError('Interceptor must be a string or callable');
     }
 }

--- a/src/general.php
+++ b/src/general.php
@@ -457,6 +457,6 @@ function sideEffect($interceptor): Closure
             return $value;
         };
     } else {
-        throw new \TypeError('Interceptor must be a string or callable');
+        throw new TypeError('Interceptor must be a string or callable');
     }
 }


### PR DESCRIPTION
Adds a function that allows 'side-effect' functions (that may or may not return anything) to be inserted in the pipe/compose flow. This allows var_dump, or other debugging functions to be used to show the state of the input at any given point. Any return from the inserted function is ignored and the input is returned unchanged.