### PR TITLE
Feature/gh9 arrays iterable

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: PHPUnit
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop, 'release/1.0.0' ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master, develop, 'release/1.0.0' ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -552,6 +552,47 @@ $sortBookByAuthor($dataBooks);
 ```
 ****
 
+### Iterable support (v1.0.0+)
+
+From `1.0.0` onwards, every data-transforming function in the `Arrays\` namespace accepts any `iterable` — arrays, `Generator`s, `Iterator`s, and any other `Traversable`. Two output contracts apply:
+
+- **Array in → array out.** Existing call sites keep returning arrays with identical shape. No breakage.
+- **Generator (or other Traversable) in → Generator out** for the *lazy* functions; *materialised* result (array / int / bool / string / object) for *terminal* functions.
+
+This lets you feed a `compose` / `pipe` chain a lazy source and keep it lazy end-to-end, until a terminal step collapses it:
+
+```php
+$pipeline = Func\compose(
+    Arr\filter(fn($x) => $x > 0),
+    Arr\map(fn($x) => $x * 10),
+    Arr\take(5)
+);
+
+// Array → array, unchanged:
+$pipeline([1, -2, 3, -4, 5, 6, 7]);        // [10, 30, 50, 60, 70]
+
+// Generator → Generator, lazy; source is only pulled far enough to yield 5 values:
+$bigStream = (function () { $i = 1; while (true) { yield $i++; } })();
+foreach ($pipeline($bigStream) as $v) { echo "$v\n"; } // 10, 20, 30, 40, 50
+```
+
+#### Which functions are lazy?
+
+| Category | Functions |
+|---|---|
+| **Lazy** (yield Generator for iterable input) | `append`, `prepend`, `tail`, `head` (early-exit), `map`, `mapKey`, `mapWith`, `mapWithKey`, `filter`, `filterKey`, `filterAnd`, `filterOr`, `filterMap`, `take`, `takeUntil`, `takeWhile`, `zip`, `chunk`, `column`, `flatMap`, `flattenByN`, `scan`, `scanR` |
+| **Short-circuit terminal** (don't fully consume when they can bail early) | `filterFirst`, `filterAll`, `filterAny`, `head` |
+| **Full-consume terminal** (materialise to produce a result) | `last`, `takeLast`, `filterLast`, `filterCount`, `partition`, `groupBy`, `toString`, `toObject`, `toJson`, `sumWhere`, `pick`, `replace`, `replaceRecursive`, `fold`, `foldR`, `foldKeys`, all `sort` variants |
+
+#### Caveats
+
+1. **Generators are single-shot.** Once exhausted they cannot be rewound. Iterating a pipeline result twice yields empty on the second pass — this is a PHP Generator fact of life, not a library choice.
+2. **Infinite Generators work with early-exit pipelines** (`head`, `take`, `filterFirst`, `filterAll` on first false, `filterAny` on first true). They hang forever with full-consume terminals (`sort`, `fold`, `groupBy`, etc.) — that's your call, not ours.
+3. **Key collisions** when materialising a Generator to an array (inside terminal fns) follow PHP's native behaviour: duplicate keys overwrite earlier values.
+4. **`tail` on an empty Generator** yields an empty Generator rather than returning `null` (the array-path behaviour for empty input). The array path is unchanged.
+
+****
+
 ### Contributions
 
 If you would like to contribute to this project, please feel to fork the project on github and submit a pull request.
@@ -588,6 +629,9 @@ If you would like to contribute to this project, please feel to fork the project
     * `GeneralFunctions\toArray()` → use `Objects\toArray()`
   * `Arrays\tail()` now works as expected, returning the array without the first element.
   * `Strings\allowTags()` now accepts an array of allowed tags even for pre PHP 7.4.
+  * **Iterable support**
+  * Every data-transforming `Arrays\*` function now accepts any `iterable` — arrays, `Generator`s, `Iterator`s, any `Traversable` — not just `array`. See the "Iterable support" section above for the full contract, the lazy/terminal classification, and the gotchas (single-shot Generators, infinite streams, key collisions, `tail` on empty).
+  * Lazy functions (`map`, `filter`, `take`, `chunk`, `zip`, `flatMap`, `scan`, …) return a `Generator` for `Traversable` input and an `array` for `array` input — pipelines stay lazy end-to-end when the source is lazy, and fully backward-compatible when the source is an array.
   * **Other Changes**
   * Made `Arrays\filterFirst()` and `Arrays\filterLast()` more efficient.
   * Bumped dev deps: phpstan `^1.0 || ^2.0`, phpunit `^7.5 || ^8.5 || ^9.6`, phpunit-polyfills `^1.0 || ^2.0 || ^4.0`.

--- a/Tests/arrays/test-array-filter-and-map.php
+++ b/Tests/arrays/test-array-filter-and-map.php
@@ -208,7 +208,9 @@ class ArrayFilterAndMapTests extends TestCase
     {
         // First match is 'b'. Source throws at index 2 — filterFirst must not reach it.
         $src = self::genThrowAt(array('a', 'b', 'c'), 2);
-        $this->assertSame('b', Arr\filterFirst(fn ($v) => $v === 'b')($src));
+        $this->assertSame('b', Arr\filterFirst(function ($v) {
+            return $v === 'b';
+        })($src));
     }
 
     /** @testdox filterAll() should accept a Generator and short-circuit on the first non-matching value. */
@@ -217,7 +219,9 @@ class ArrayFilterAndMapTests extends TestCase
         // Values 1, 2 are all truthy; value at index 2 (-1) is negative.
         // Source throws at index 3 — filterAll returns false at index 2 and never advances.
         $src = self::genThrowAt(array(1, 2, -1, 3), 3);
-        $this->assertFalse(Arr\filterAll(fn ($v) => $v > 0)($src));
+        $this->assertFalse(Arr\filterAll(function ($v) {
+            return $v > 0;
+        })($src));
     }
 
     /** @testdox filterAny() should accept a Generator and short-circuit on the first matching value. */
@@ -226,7 +230,9 @@ class ArrayFilterAndMapTests extends TestCase
         // Value at index 1 matches. Source throws at index 2 — filterAny returns
         // true at index 1 and never advances.
         $src = self::genThrowAt(array(1, 2, 3), 2);
-        $this->assertTrue(Arr\filterAny(fn ($v) => $v === 2)($src));
+        $this->assertTrue(Arr\filterAny(function ($v) {
+            return $v === 2;
+        })($src));
     }
 
     public function testCanMapArrayKeys(): void
@@ -291,7 +297,9 @@ class ArrayFilterAndMapTests extends TestCase
     /** @testdox map() should still return an array when the input is an array (back-compat). */
     public function testMapReturnsArrayForArrayInput(): void
     {
-        $result = Arr\map(fn ($x) => $x * 2)(array(1, 2, 3));
+        $result = Arr\map(function ($x) {
+            return $x * 2;
+        })(array(1, 2, 3));
         $this->assertIsArray($result);
         $this->assertSame(array(2, 4, 6), $result);
     }
@@ -300,7 +308,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testMapReturnsGeneratorForGeneratorInput(): void
     {
         $src    = self::gen(array('a' => 1, 'b' => 2, 'c' => 3));
-        $result = Arr\map(fn ($x) => $x * 10)($src);
+        $result = Arr\map(function ($x) {
+            return $x * 10;
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array('a' => 10, 'b' => 20, 'c' => 30), iterator_to_array($result));
@@ -310,7 +320,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testMapEmptyGeneratorYieldsNothing(): void
     {
         $empty  = self::gen(array());
-        $result = Arr\map(fn ($x) => $x)($empty);
+        $result = Arr\map(function ($x) {
+            return $x;
+        })($empty);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array(), iterator_to_array($result));
@@ -343,7 +355,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testFilterReturnsGeneratorForGeneratorInput(): void
     {
         $src    = self::gen(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4));
-        $result = Arr\filter(fn ($x) => $x % 2 === 0)($src);
+        $result = Arr\filter(function ($x) {
+            return $x % 2 === 0;
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array('b' => 2, 'd' => 4), iterator_to_array($result));
@@ -353,7 +367,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testFilterKeyReturnsGeneratorForGeneratorInput(): void
     {
         $src    = self::gen(array('keep_a' => 1, 'drop_b' => 2, 'keep_c' => 3));
-        $result = Arr\filterKey(fn ($k) => strpos($k, 'keep_') === 0)($src);
+        $result = Arr\filterKey(function ($k) {
+            return strpos($k, 'keep_') === 0;
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array('keep_a' => 1, 'keep_c' => 3), iterator_to_array($result));
@@ -364,8 +380,12 @@ class ArrayFilterAndMapTests extends TestCase
     {
         $src    = self::gen(array(1, 2, 3, 4, 5, 6));
         $result = Arr\filterAnd(
-            fn ($x) => $x > 2,
-            fn ($x) => $x % 2 === 0
+            function ($x) {
+                return $x > 2;
+            },
+            function ($x) {
+                return $x % 2 === 0;
+            }
         )($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
@@ -377,8 +397,12 @@ class ArrayFilterAndMapTests extends TestCase
     {
         $src    = self::gen(array(1, 2, 3, 4, 5));
         $result = Arr\filterOr(
-            fn ($x) => $x === 1,
-            fn ($x) => $x === 5
+            function ($x) {
+                return $x === 1;
+            },
+            function ($x) {
+                return $x === 5;
+            }
         )($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
@@ -390,8 +414,12 @@ class ArrayFilterAndMapTests extends TestCase
     {
         $src    = self::gen(array(1, 2, 3, 4, 5));
         $result = Arr\filterMap(
-            fn ($x) => $x % 2 === 0,
-            fn ($x) => $x * 10
+            function ($x) {
+                return $x % 2 === 0;
+            },
+            function ($x) {
+                return $x * 10;
+            }
         )($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
@@ -412,7 +440,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testMapWithReturnsGeneratorForGeneratorInput(): void
     {
         $src    = self::gen(array('a' => 1, 'b' => 2));
-        $result = Arr\mapWith(fn ($v, $suffix) => "{$v}{$suffix}", '!')($src);
+        $result = Arr\mapWith(function ($v, $suffix) {
+            return "{$v}{$suffix}";
+        }, '!')($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array('a' => '1!', 'b' => '2!'), iterator_to_array($result));
@@ -422,7 +452,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testMapWithKeyReturnsGeneratorForGeneratorInput(): void
     {
         $src    = self::gen(array('a' => 1, 'b' => 2));
-        $result = Arr\mapWithKey(fn ($v, $k) => "{$k}:{$v}")($src);
+        $result = Arr\mapWithKey(function ($v, $k) {
+            return "{$k}:{$v}";
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         // array path returns [0 => 'a:1', 1 => 'b:2'] because array_map with
@@ -467,7 +499,9 @@ class ArrayFilterAndMapTests extends TestCase
     public function testFlatMapReturnsGeneratorForGeneratorInput(): void
     {
         $src    = self::gen(array(1, array(2, array(3, 4)), 5));
-        $result = Arr\flatMap(fn ($x) => $x * 10)($src);
+        $result = Arr\flatMap(function ($x) {
+            return $x * 10;
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array(10, 20, 30, 40, 50), iterator_to_array($result, false));
@@ -478,7 +512,9 @@ class ArrayFilterAndMapTests extends TestCase
     {
         // Depth 1: top-level nested arrays flatten one level; deeper arrays stay as arrays.
         $src    = self::gen(array(1, array(2, array(3, 4)), 5));
-        $result = Arr\flatMap(fn ($x) => $x * 10, 1)($src);
+        $result = Arr\flatMap(function ($x) {
+            return $x * 10;
+        }, 1)($src);
 
         $this->assertSame(array(10, 20, array(3, 4), 50), iterator_to_array($result, false));
     }

--- a/Tests/arrays/test-array-filter-and-map.php
+++ b/Tests/arrays/test-array-filter-and-map.php
@@ -26,6 +26,38 @@ class ArrayFilterAndMapTests extends TestCase
         FunctionsLoader::include();
     }
 
+    /**
+     * Helper: wraps an array in a one-shot Generator so tests can exercise the
+     * iterable branch of the Arrays\* fns.
+     *
+     * @param array<int|string, mixed> $data
+     * @return \Generator<int|string, mixed>
+     */
+    private static function gen(array $data): \Generator
+    {
+        foreach ($data as $k => $v) {
+            yield $k => $v;
+        }
+    }
+
+    /**
+     * Helper: Generator that throws the moment the consumer asks for the
+     * element at index $throwOn. Used to prove a lazy fn does NOT consume
+     * past its short-circuit point.
+     *
+     * @param array<int|string, mixed> $data
+     */
+    private static function genThrowAt(array $data, int $throwOn): \Generator
+    {
+        $i = 0;
+        foreach ($data as $k => $v) {
+            if ($i++ === $throwOn) {
+                throw new \RuntimeException('Generator consumed past the short-circuit point');
+            }
+            yield $k => $v;
+        }
+    }
+
     public function testCanUseFilter()
     {
         $names = array( 'James Smith', 'Betty Jones', 'Sam Power', 'Rebecca Smith' );
@@ -228,6 +260,57 @@ class ArrayFilterAndMapTests extends TestCase
         // Check inital array the same.
         $this->assertEquals('aa', $origArray['a']);
         $this->assertNotEquals('AA', $origArray['a']);
+    }
+
+    /** @testdox map() should still return an array when the input is an array (back-compat). */
+    public function testMapReturnsArrayForArrayInput(): void
+    {
+        $result = Arr\map(fn ($x) => $x * 2)(array(1, 2, 3));
+        $this->assertIsArray($result);
+        $this->assertSame(array(2, 4, 6), $result);
+    }
+
+    /** @testdox map() should return a lazy Generator when the input is a Generator, yielding transformed values with keys preserved. */
+    public function testMapReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('a' => 1, 'b' => 2, 'c' => 3));
+        $result = Arr\map(fn ($x) => $x * 10)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('a' => 10, 'b' => 20, 'c' => 30), iterator_to_array($result));
+    }
+
+    /** @testdox map() over an empty Generator should yield nothing (empty Generator returned). */
+    public function testMapEmptyGeneratorYieldsNothing(): void
+    {
+        $empty  = self::gen(array());
+        $result = Arr\map(fn ($x) => $x)($empty);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(), iterator_to_array($result));
+    }
+
+    /** @testdox map() over a Generator must stay lazy \u2014 elements past the consumer's demand should not be pulled from the source. */
+    public function testMapIsLazyOverGenerator(): void
+    {
+        // Generator throws the moment index 2 is requested. If map() were eager
+        // it would materialise the whole thing and throw during the initial call.
+        $src    = self::genThrowAt(array('a', 'b', 'c', 'd'), 2);
+        $result = Arr\map('strtoupper')($src);
+
+        // Pulling only the first two items must not trip the throw at index 2.
+        $first  = null;
+        $second = null;
+        foreach ($result as $i => $v) {
+            if ($first === null) {
+                $first = $v;
+                continue;
+            }
+            $second = $v;
+            break; // consumer stops here; source should NOT be advanced further
+        }
+        $this->assertSame('A', $first);
+        $this->assertSame('B', $second);
     }
 
     public function testCanUseFlatMap(): void

--- a/Tests/arrays/test-array-filter-and-map.php
+++ b/Tests/arrays/test-array-filter-and-map.php
@@ -203,6 +203,32 @@ class ArrayFilterAndMapTests extends TestCase
         );
     }
 
+    /** @testdox filterFirst() should accept a Generator and return the first match without consuming the source further. */
+    public function testFilterFirstAcceptsGeneratorAndShortCircuits(): void
+    {
+        // First match is 'b'. Source throws at index 2 — filterFirst must not reach it.
+        $src = self::genThrowAt(array('a', 'b', 'c'), 2);
+        $this->assertSame('b', Arr\filterFirst(fn ($v) => $v === 'b')($src));
+    }
+
+    /** @testdox filterAll() should accept a Generator and short-circuit on the first non-matching value. */
+    public function testFilterAllAcceptsGeneratorAndShortCircuitsOnFalse(): void
+    {
+        // Values 1, 2 are all truthy; value at index 2 (-1) is negative.
+        // Source throws at index 3 — filterAll returns false at index 2 and never advances.
+        $src = self::genThrowAt(array(1, 2, -1, 3), 3);
+        $this->assertFalse(Arr\filterAll(fn ($v) => $v > 0)($src));
+    }
+
+    /** @testdox filterAny() should accept a Generator and short-circuit on the first matching value. */
+    public function testFilterAnyAcceptsGeneratorAndShortCircuitsOnTrue(): void
+    {
+        // Value at index 1 matches. Source throws at index 2 — filterAny returns
+        // true at index 1 and never advances.
+        $src = self::genThrowAt(array(1, 2, 3), 2);
+        $this->assertTrue(Arr\filterAny(fn ($v) => $v === 2)($src));
+    }
+
     public function testCanMapArrayKeys(): void
     {
         $origArray = array(

--- a/Tests/arrays/test-array-filter-and-map.php
+++ b/Tests/arrays/test-array-filter-and-map.php
@@ -313,6 +313,97 @@ class ArrayFilterAndMapTests extends TestCase
         $this->assertSame('B', $second);
     }
 
+    /** @testdox filter() should return a lazy Generator preserving keys when given a Generator. */
+    public function testFilterReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4));
+        $result = Arr\filter(fn ($x) => $x % 2 === 0)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('b' => 2, 'd' => 4), iterator_to_array($result));
+    }
+
+    /** @testdox filterKey() should return a lazy Generator filtering on keys when given a Generator. */
+    public function testFilterKeyReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('keep_a' => 1, 'drop_b' => 2, 'keep_c' => 3));
+        $result = Arr\filterKey(fn ($k) => strpos($k, 'keep_') === 0)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('keep_a' => 1, 'keep_c' => 3), iterator_to_array($result));
+    }
+
+    /** @testdox filterAnd() should return a lazy Generator applying an AND group of predicates to a Generator source. */
+    public function testFilterAndReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, 2, 3, 4, 5, 6));
+        $result = Arr\filterAnd(
+            fn ($x) => $x > 2,
+            fn ($x) => $x % 2 === 0
+        )($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(3 => 4, 5 => 6), iterator_to_array($result));
+    }
+
+    /** @testdox filterOr() should return a lazy Generator applying an OR group of predicates to a Generator source. */
+    public function testFilterOrReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, 2, 3, 4, 5));
+        $result = Arr\filterOr(
+            fn ($x) => $x === 1,
+            fn ($x) => $x === 5
+        )($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(0 => 1, 4 => 5), iterator_to_array($result));
+    }
+
+    /** @testdox filterMap() should return a lazy Generator filter-then-mapping over a Generator source. */
+    public function testFilterMapReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, 2, 3, 4, 5));
+        $result = Arr\filterMap(
+            fn ($x) => $x % 2 === 0,
+            fn ($x) => $x * 10
+        )($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(1 => 20, 3 => 40), iterator_to_array($result));
+    }
+
+    /** @testdox mapKey() should return a lazy Generator transforming keys when given a Generator. */
+    public function testMapKeyReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('a' => 1, 'b' => 2));
+        $result = Arr\mapKey('strtoupper')($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('A' => 1, 'B' => 2), iterator_to_array($result));
+    }
+
+    /** @testdox mapWith() should return a lazy Generator applying the callback with extra data when given a Generator. */
+    public function testMapWithReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('a' => 1, 'b' => 2));
+        $result = Arr\mapWith(fn ($v, $suffix) => "{$v}{$suffix}", '!')($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('a' => '1!', 'b' => '2!'), iterator_to_array($result));
+    }
+
+    /** @testdox mapWithKey() should return a lazy Generator supplying (value, key) to the callback; keys re-index to match the array path. */
+    public function testMapWithKeyReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('a' => 1, 'b' => 2));
+        $result = Arr\mapWithKey(fn ($v, $k) => "{$k}:{$v}")($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        // array path returns [0 => 'a:1', 1 => 'b:2'] because array_map with
+        // multiple arrays re-indexes — Generator path matches that shape.
+        $this->assertSame(array(0 => 'a:1', 1 => 'b:2'), iterator_to_array($result));
+    }
+
     public function testCanUseFlatMap(): void
     {
         $array = array(

--- a/Tests/arrays/test-array-filter-and-map.php
+++ b/Tests/arrays/test-array-filter-and-map.php
@@ -462,4 +462,24 @@ class ArrayFilterAndMapTests extends TestCase
         $this->assertEquals(16, $doubleNFlattenIt($array)[8]);
         $this->assertEquals(4, $doubleNFlattenIt($array)[2]);
     }
+
+    /** @testdox flatMap() should return a lazy Generator that recursively flattens nested arrays in a Generator source, applying the callback to leaf values. */
+    public function testFlatMapReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, array(2, array(3, 4)), 5));
+        $result = Arr\flatMap(fn ($x) => $x * 10)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(10, 20, 30, 40, 50), iterator_to_array($result, false));
+    }
+
+    /** @testdox flatMap() with a depth limit should respect it when recursing into a Generator source. */
+    public function testFlatMapRespectsDepthLimitOverGenerator(): void
+    {
+        // Depth 1: top-level nested arrays flatten one level; deeper arrays stay as arrays.
+        $src    = self::gen(array(1, array(2, array(3, 4)), 5));
+        $result = Arr\flatMap(fn ($x) => $x * 10, 1)($src);
+
+        $this->assertSame(array(10, 20, array(3, 4), 50), iterator_to_array($result, false));
+    }
 }

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -273,6 +273,28 @@ class ArrayFunctionTests extends TestCase
         $this->assertEquals('Fay', $chunkedNames[1][3]);
     }
 
+    /** @testdox chunk() should return a lazy Generator yielding batches of N, including a partial final batch when the source length doesn't divide cleanly. */
+    public function testChunkReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, 2, 3, 4, 5));
+        $result = Arr\chunk(2)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(array(1, 2), array(3, 4), array(5)), iterator_to_array($result, false));
+    }
+
+    /** @testdox chunk() with preserveKeys over a Generator keeps the original keys inside each batch. */
+    public function testChunkPreservesKeysOverGenerator(): void
+    {
+        $src    = self::gen(array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4));
+        $result = Arr\chunk(2, true)($src);
+
+        $this->assertSame(
+            array(array('a' => 1, 'b' => 2), array('c' => 3, 'd' => 4)),
+            iterator_to_array($result, false)
+        );
+    }
+
     public function testCanUseZip()
     {
         $array = array( 'a', 'b', 'c' );
@@ -288,6 +310,19 @@ class ArrayFunctionTests extends TestCase
         $expectedFull = array( array( 'a', 'A' ), array( 'b', 'B' ), array( 'c', 'C' ) );
         $resultFull   = Arr\zip($arrayFull, 'FALLBACK')($array);
         $this->assertSame($resultFull, $expectedFull);
+    }
+
+    /** @testdox zip() should return a lazy Generator pairing source values with the additional array, using the default when the additional runs out. */
+    public function testZipReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array('a', 'b', 'c'));
+        $result = Arr\zip(array('A', 'B'), 'FALLBACK')($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(
+            array(array('a', 'A'), array('b', 'B'), array('c', 'FALLBACK')),
+            iterator_to_array($result, false)
+        );
     }
 
     public function testCanUseColumn(): void
@@ -347,6 +382,26 @@ class ArrayFunctionTests extends TestCase
         $this->assertArrayHasKey('Duke', $getUsersRandoms($data));
         $this->assertArrayNotHasKey(2, $getUsersRandoms($data));
         $this->assertArrayHasKey('Bazza', $getUsersRandoms($data));
+    }
+
+    /** @testdox column() should return a lazy Generator yielding the named column from each Generator element. */
+    public function testColumnReturnsGeneratorForGeneratorInput(): void
+    {
+        $rows = array(
+            array('id' => 1, 'name' => 'Alice'),
+            array('id' => 2, 'name' => 'Bob'),
+            array('id' => 3, 'name' => 'Charlie'),
+        );
+
+        // Without an index column — sequential integer keys.
+        $names = Arr\column('name')(self::gen($rows));
+        $this->assertInstanceOf(\Generator::class, $names);
+        $this->assertSame(array('Alice', 'Bob', 'Charlie'), iterator_to_array($names, false));
+
+        // With an index column — keyed by id.
+        $namesById = Arr\column('name', 'id')(self::gen($rows));
+        $this->assertInstanceOf(\Generator::class, $namesById);
+        $this->assertSame(array(1 => 'Alice', 2 => 'Bob', 3 => 'Charlie'), iterator_to_array($namesById));
     }
 
     /** @testdox It should be possible to flatten an array by any number of nodes. */

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -172,6 +172,41 @@ class ArrayFunctionTests extends TestCase
         $this->assertNull(Arr\head(array()));
     }
 
+    /** @testdox head() accepts any iterable. For a Generator it returns the first yielded value without consuming the rest. */
+    public function testHeadAcceptsGenerator(): void
+    {
+        $this->assertSame('first', Arr\head(self::gen(array('first', 'second', 'third'))));
+        $this->assertNull(Arr\head(self::gen(array())));
+    }
+
+    /** @testdox head() must not consume the source Generator beyond the first yielded value. */
+    public function testHeadIsLazyOverGenerator(): void
+    {
+        // Source throws the moment index 1 is requested. head() should return
+        // the first value without ever advancing to trip the throw.
+        $src = self::genThrowAt(array('ok'), 1);
+        $this->assertSame('ok', Arr\head($src));
+    }
+
+    /** @testdox last() accepts any iterable and returns the final value (materialises Generators). */
+    public function testLastAcceptsGenerator(): void
+    {
+        $this->assertSame('third', Arr\last(self::gen(array('first', 'second', 'third'))));
+        $this->assertNull(Arr\last(self::gen(array())));
+    }
+
+    /** @testdox tail() over a Generator lazily yields every element after the first. Empty Generator yields an empty Generator (not null). */
+    public function testTailAcceptsGenerator(): void
+    {
+        $result = Arr\tail(self::gen(array(1, 2, 3, 4)));
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(2, 3, 4), iterator_to_array($result, false));
+
+        $empty = Arr\tail(self::gen(array()));
+        $this->assertInstanceOf(\Generator::class, $empty);
+        $this->assertSame(array(), iterator_to_array($empty, false));
+    }
+
     public function testCanCompileArray(): void
     {
         $arrayCompiler = Arr\arrayCompiler();

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -1514,4 +1514,98 @@ class ArrayFunctionTests extends TestCase
             $pick($data)
         );
     }
+
+    /*
+     * B10 — TERMINAL shim tests.
+     *
+     * These fns don't return a Generator, but they accept one now. Each test
+     * asserts Generator input produces the same result as array input.
+     */
+
+    /** @testdox toString() accepts any iterable and joins values with the glue. */
+    public function testToStringAcceptsGenerator(): void
+    {
+        $this->assertSame('1-2-3', Arr\toString('-')(self::gen(array(1, 2, 3))));
+        $this->assertSame('abc', Arr\toString()(self::gen(array('a', 'b', 'c'))));
+    }
+
+    /** @testdox filterCount() accepts any iterable and returns the number of matches. */
+    public function testFilterCountAcceptsGenerator(): void
+    {
+        $this->assertSame(3, Arr\filterCount(fn ($v) => $v % 2 === 0)(self::gen(array(1, 2, 3, 4, 5, 6))));
+    }
+
+    /** @testdox filterLast() accepts any iterable and returns the last matching value. */
+    public function testFilterLastAcceptsGenerator(): void
+    {
+        $this->assertSame(6, Arr\filterLast(fn ($v) => $v % 2 === 0)(self::gen(array(1, 3, 4, 6))));
+        $this->assertNull(Arr\filterLast(fn ($v) => $v > 100)(self::gen(array(1, 2, 3))));
+    }
+
+    /** @testdox partition() accepts any iterable and returns the [truthy, falsy] buckets. */
+    public function testPartitionAcceptsGenerator(): void
+    {
+        $result = Arr\partition(fn ($v) => $v > 2)(self::gen(array(1, 2, 3, 4, 5)));
+        $this->assertSame(array(array(1, 2), array(3, 4, 5)), $result);
+    }
+
+    /** @testdox groupBy() accepts any iterable and groups by the key-producing callback. */
+    public function testGroupByAcceptsGenerator(): void
+    {
+        $src = self::gen(array('apple', 'avocado', 'banana', 'blueberry'));
+        $byFirstChar = Arr\groupBy(fn ($v) => $v[0])($src);
+        $this->assertSame(
+            array('a' => array('apple', 'avocado'), 'b' => array('banana', 'blueberry')),
+            $byFirstChar
+        );
+    }
+
+    /** @testdox sumWhere() accepts any iterable and sums the callback outputs. */
+    public function testSumWhereAcceptsGenerator(): void
+    {
+        $src = self::gen(array(array('qty' => 2), array('qty' => 3), array('qty' => 5)));
+        $this->assertSame(10, Arr\sumWhere(fn ($row) => $row['qty'])($src));
+    }
+
+    /** @testdox toObject() accepts any iterable and casts it into the given object. */
+    public function testToObjectAcceptsGenerator(): void
+    {
+        $src = self::gen(array('a' => 1, 'b' => 2));
+        $obj = Arr\toObject()($src);
+        $this->assertSame(1, $obj->a);
+        $this->assertSame(2, $obj->b);
+    }
+
+    /** @testdox replace() accepts any iterable and replaces matching keys. */
+    public function testReplaceAcceptsGenerator(): void
+    {
+        $src = self::gen(array(0 => 'a', 1 => 'b', 2 => 'c'));
+        $this->assertSame(
+            array(0 => 'A', 1 => 'b', 2 => 'c'),
+            Arr\replace(array(0 => 'A'))($src)
+        );
+    }
+
+    /** @testdox replaceRecursive() accepts any iterable and deep-replaces matching keys. */
+    public function testReplaceRecursiveAcceptsGenerator(): void
+    {
+        $src = self::gen(array('a' => array('x' => 1, 'y' => 2), 'b' => 3));
+        $this->assertSame(
+            array('a' => array('x' => 9, 'y' => 2), 'b' => 3),
+            Arr\replaceRecursive(array('a' => array('x' => 9)))($src)
+        );
+    }
+
+    /** @testdox takeLast() accepts any iterable and returns the final N elements (materialises the source). */
+    public function testTakeLastAcceptsGenerator(): void
+    {
+        $this->assertSame(array(3, 4, 5), array_values(Arr\takeLast(3)(self::gen(array(1, 2, 3, 4, 5)))));
+    }
+
+    /** @testdox pick() accepts any iterable and returns only the requested keys. */
+    public function testPickAcceptsGenerator(): void
+    {
+        $src = self::gen(array('a' => 1, 'b' => 2, 'c' => 3));
+        $this->assertSame(array('a' => 1, 'c' => 3), Arr\pick('a', 'c')($src));
+    }
 }

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -692,7 +692,9 @@ class ArrayFunctionTests extends TestCase
     /** @testdox scan() should return a lazy Generator yielding the initial value then each running accumulation when given a Generator. */
     public function testScanReturnsGeneratorForGeneratorInput(): void
     {
-        $result = Arr\scan(fn ($c, $v) => $c + $v, 0)(self::gen(array(1, 2, 3, 4, 5)));
+        $result = Arr\scan(function ($c, $v) {
+            return $c + $v;
+        }, 0)(self::gen(array(1, 2, 3, 4, 5)));
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array(0, 1, 3, 6, 10, 15), iterator_to_array($result, false));
@@ -701,7 +703,9 @@ class ArrayFunctionTests extends TestCase
     /** @testdox scanR() accepts a Generator — source is materialised to reverse, but the result is still returned as a Generator for API consistency. */
     public function testScanRReturnsGeneratorForGeneratorInput(): void
     {
-        $result = Arr\scanR(fn ($c, $v) => $c + $v, 0)(self::gen(array(1, 2, 3)));
+        $result = Arr\scanR(function ($c, $v) {
+            return $c + $v;
+        }, 0)(self::gen(array(1, 2, 3)));
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array(6, 5, 3, 0), iterator_to_array($result, false));
@@ -906,7 +910,9 @@ class ArrayFunctionTests extends TestCase
         // takeUntil is properly lazy, it stops at index 2 ('STOP') and never
         // advances to trip the throw.
         $src    = self::genThrowAt(array('a', 'b', 'STOP', 'c'), 3);
-        $result = Arr\takeUntil(fn ($v) => $v === 'STOP')($src);
+        $result = Arr\takeUntil(function ($v) {
+            return $v === 'STOP';
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array('a', 'b'), iterator_to_array($result, false));
@@ -918,7 +924,9 @@ class ArrayFunctionTests extends TestCase
         // Predicate is "< 10". Source throws at index 3. takeWhile stops at
         // value 10 (index 2, first failing item) and must not advance further.
         $src    = self::genThrowAt(array(1, 2, 10, 3), 3);
-        $result = Arr\takeWhile(fn ($v) => $v < 10)($src);
+        $result = Arr\takeWhile(function ($v) {
+            return $v < 10;
+        })($src);
 
         $this->assertInstanceOf(\Generator::class, $result);
         $this->assertSame(array(1, 2), iterator_to_array($result, false));
@@ -1532,20 +1540,28 @@ class ArrayFunctionTests extends TestCase
     /** @testdox filterCount() accepts any iterable and returns the number of matches. */
     public function testFilterCountAcceptsGenerator(): void
     {
-        $this->assertSame(3, Arr\filterCount(fn ($v) => $v % 2 === 0)(self::gen(array(1, 2, 3, 4, 5, 6))));
+        $this->assertSame(3, Arr\filterCount(function ($v) {
+            return $v % 2 === 0;
+        })(self::gen(array(1, 2, 3, 4, 5, 6))));
     }
 
     /** @testdox filterLast() accepts any iterable and returns the last matching value. */
     public function testFilterLastAcceptsGenerator(): void
     {
-        $this->assertSame(6, Arr\filterLast(fn ($v) => $v % 2 === 0)(self::gen(array(1, 3, 4, 6))));
-        $this->assertNull(Arr\filterLast(fn ($v) => $v > 100)(self::gen(array(1, 2, 3))));
+        $this->assertSame(6, Arr\filterLast(function ($v) {
+            return $v % 2 === 0;
+        })(self::gen(array(1, 3, 4, 6))));
+        $this->assertNull(Arr\filterLast(function ($v) {
+            return $v > 100;
+        })(self::gen(array(1, 2, 3))));
     }
 
     /** @testdox partition() accepts any iterable and returns the [truthy, falsy] buckets. */
     public function testPartitionAcceptsGenerator(): void
     {
-        $result = Arr\partition(fn ($v) => $v > 2)(self::gen(array(1, 2, 3, 4, 5)));
+        $result = Arr\partition(function ($v) {
+            return $v > 2;
+        })(self::gen(array(1, 2, 3, 4, 5)));
         $this->assertSame(array(array(1, 2), array(3, 4, 5)), $result);
     }
 
@@ -1553,7 +1569,9 @@ class ArrayFunctionTests extends TestCase
     public function testGroupByAcceptsGenerator(): void
     {
         $src = self::gen(array('apple', 'avocado', 'banana', 'blueberry'));
-        $byFirstChar = Arr\groupBy(fn ($v) => $v[0])($src);
+        $byFirstChar = Arr\groupBy(function ($v) {
+            return $v[0];
+        })($src);
         $this->assertSame(
             array('a' => array('apple', 'avocado'), 'b' => array('banana', 'blueberry')),
             $byFirstChar
@@ -1564,7 +1582,9 @@ class ArrayFunctionTests extends TestCase
     public function testSumWhereAcceptsGenerator(): void
     {
         $src = self::gen(array(array('qty' => 2), array('qty' => 3), array('qty' => 5)));
-        $this->assertSame(10, Arr\sumWhere(fn ($row) => $row['qty'])($src));
+        $this->assertSame(10, Arr\sumWhere(function ($row) {
+            return $row['qty'];
+        })($src));
     }
 
     /** @testdox toObject() accepts any iterable and casts it into the given object. */
@@ -1627,14 +1647,18 @@ class ArrayFunctionTests extends TestCase
     public function testUsortAcceptsGenerator(): void
     {
         $src = self::gen(array(5, 3, 8, 1));
-        $desc = Arr\usort(fn ($a, $b) => $b - $a);
+        $desc = Arr\usort(function ($a, $b) {
+            return $b - $a;
+        });
         $this->assertSame(array(8, 5, 3, 1), $desc($src));
     }
 
     /** @testdox fold() accepts any iterable and reduces left-to-right via a streaming foreach (no materialisation). */
     public function testFoldAcceptsGenerator(): void
     {
-        $sum = Arr\fold(fn ($acc, $v) => $acc + $v, 0);
+        $sum = Arr\fold(function ($acc, $v) {
+            return $acc + $v;
+        }, 0);
         $this->assertSame(15, $sum(self::gen(array(1, 2, 3, 4, 5))));
     }
 
@@ -1642,14 +1666,18 @@ class ArrayFunctionTests extends TestCase
     public function testFoldRAcceptsGenerator(): void
     {
         // Concatenate right-to-left to prove direction: "c","b","a" → "cba"
-        $cat = Arr\foldR(fn ($acc, $v) => $acc . $v, '');
+        $cat = Arr\foldR(function ($acc, $v) {
+            return $acc . $v;
+        }, '');
         $this->assertSame('cba', $cat(self::gen(array('a', 'b', 'c'))));
     }
 
     /** @testdox foldKeys() accepts any iterable and supplies the key to the callback. */
     public function testFoldKeysAcceptsGenerator(): void
     {
-        $joined = Arr\foldKeys(fn ($acc, $k, $v) => $acc . "$k=$v;", '');
+        $joined = Arr\foldKeys(function ($acc, $k, $v) {
+            return $acc . "$k=$v;";
+        }, '');
         $this->assertSame('a=1;b=2;', $joined(self::gen(array('a' => 1, 'b' => 2))));
     }
 }

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -785,6 +785,52 @@ class ArrayFunctionTests extends TestCase
         $this->assertEquals($data, $takeWhile($data));
     }
 
+    /** @testdox take() should return a lazy Generator that stops after N items without consuming the source further. */
+    public function testTakeReturnsGeneratorForGeneratorInput(): void
+    {
+        // Generator throws if asked for index 2. take(2) should consume only
+        // indices 0 and 1 and succeed.
+        $src    = self::genThrowAt(array('a', 'b', 'c', 'd'), 2);
+        $result = Arr\take(2)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('a', 'b'), iterator_to_array($result, false));
+    }
+
+    /** @testdox take(0) over a Generator yields an empty Generator. */
+    public function testTakeZeroOverGeneratorYieldsEmpty(): void
+    {
+        $result = Arr\take(0)(self::gen(array('a', 'b', 'c')));
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(), iterator_to_array($result, false));
+    }
+
+    /** @testdox takeUntil() should return a lazy Generator that stops at the first value where the predicate returns true. */
+    public function testTakeUntilReturnsGeneratorForGeneratorInput(): void
+    {
+        // Predicate is "value === 'STOP'". Source throws at index 3 — if
+        // takeUntil is properly lazy, it stops at index 2 ('STOP') and never
+        // advances to trip the throw.
+        $src    = self::genThrowAt(array('a', 'b', 'STOP', 'c'), 3);
+        $result = Arr\takeUntil(fn ($v) => $v === 'STOP')($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('a', 'b'), iterator_to_array($result, false));
+    }
+
+    /** @testdox takeWhile() should return a lazy Generator that stops at the first value where the predicate returns false. */
+    public function testTakeWhileReturnsGeneratorForGeneratorInput(): void
+    {
+        // Predicate is "< 10". Source throws at index 3. takeWhile stops at
+        // value 10 (index 2, first failing item) and must not advance further.
+        $src    = self::genThrowAt(array(1, 2, 10, 3), 3);
+        $result = Arr\takeWhile(fn ($v) => $v < 10)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(1, 2), iterator_to_array($result, false));
+    }
+
     /** @testdox It should be possible to use Map() and have access to key and value. */
     public function testMapWithKeys(): void
     {

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -1608,4 +1608,26 @@ class ArrayFunctionTests extends TestCase
         $src = self::gen(array('a' => 1, 'b' => 2, 'c' => 3));
         $this->assertSame(array('a' => 1, 'c' => 3), Arr\pick('a', 'c')($src));
     }
+
+    /** @testdox sort() accepts any iterable; keys are re-indexed as per native sort(). */
+    public function testSortAcceptsGenerator(): void
+    {
+        $src = self::gen(array('b', 'a', 'c'));
+        $this->assertSame(array('a', 'b', 'c'), Arr\sort()($src));
+    }
+
+    /** @testdox asort() accepts any iterable; keys are preserved. */
+    public function testAsortAcceptsGenerator(): void
+    {
+        $src = self::gen(array('x' => 3, 'y' => 1, 'z' => 2));
+        $this->assertSame(array('y' => 1, 'z' => 2, 'x' => 3), Arr\asort()($src));
+    }
+
+    /** @testdox usort() accepts any iterable and sorts with a custom comparator. */
+    public function testUsortAcceptsGenerator(): void
+    {
+        $src = self::gen(array(5, 3, 8, 1));
+        $desc = Arr\usort(fn ($a, $b) => $b - $a);
+        $this->assertSame(array(8, 5, 3, 1), $desc($src));
+    }
 }

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -962,6 +962,19 @@ class ArrayFunctionTests extends TestCase
         $iterate($data);
     }
 
+    /** @testdox each() accepts any iterable and invokes the callback with each (key, value) pair from a Generator source. */
+    public function testEachAcceptsGenerator(): void
+    {
+        $collected = array();
+        $iterate   = Arr\each(function ($key, $value) use (&$collected): void {
+            $collected[$key] = $value;
+        });
+
+        $iterate(self::gen(array('a' => 1, 'b' => 2, 'c' => 3)));
+
+        $this->assertSame(array('a' => 1, 'b' => 2, 'c' => 3), $collected);
+    }
+
     /** @testdox It should be possible to create a function that is populated with a filter predicate, which when used on an array will return a count of matching values. */
     public function testCountBy(): void
     {

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -689,6 +689,24 @@ class ArrayFunctionTests extends TestCase
         $this->assertEquals($expected, $scanR($initial));
     }
 
+    /** @testdox scan() should return a lazy Generator yielding the initial value then each running accumulation when given a Generator. */
+    public function testScanReturnsGeneratorForGeneratorInput(): void
+    {
+        $result = Arr\scan(fn ($c, $v) => $c + $v, 0)(self::gen(array(1, 2, 3, 4, 5)));
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(0, 1, 3, 6, 10, 15), iterator_to_array($result, false));
+    }
+
+    /** @testdox scanR() accepts a Generator — source is materialised to reverse, but the result is still returned as a Generator for API consistency. */
+    public function testScanRReturnsGeneratorForGeneratorInput(): void
+    {
+        $result = Arr\scanR(fn ($c, $v) => $c + $v, 0)(self::gen(array(1, 2, 3)));
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(6, 5, 3, 0), iterator_to_array($result, false));
+    }
+
     /** @testdox It should be possible to create a function, pre defined to perform fold/reduce on a given array. */
     public function testFold(): void
     {

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -42,6 +42,38 @@ class ArrayFunctionTests extends TestCase
         FunctionsLoader::include();
     }
 
+    /**
+     * Helper: wraps an array in a one-shot Generator so tests can exercise the
+     * iterable branch of the Arrays\* fns.
+     *
+     * @param array<int|string, mixed> $data
+     * @return \Generator<int|string, mixed>
+     */
+    private static function gen(array $data): \Generator
+    {
+        foreach ($data as $k => $v) {
+            yield $k => $v;
+        }
+    }
+
+    /**
+     * Helper: Generator that throws the moment the consumer asks for the
+     * element at index $throwOn. Used to prove a lazy fn does NOT consume
+     * past its short-circuit point.
+     *
+     * @param array<int|string, mixed> $data
+     */
+    private static function genThrowAt(array $data, int $throwOn): \Generator
+    {
+        $i = 0;
+        foreach ($data as $k => $v) {
+            if ($i++ === $throwOn) {
+                throw new \RuntimeException('Generator consumed past the short-circuit point');
+            }
+            yield $k => $v;
+        }
+    }
+
     /** @testdox It should be possible to prepend and item to an array. */
     public function testCanPrependToArray(): void
     {
@@ -74,6 +106,43 @@ class ArrayFunctionTests extends TestCase
         $this->assertEquals(6, $new[5]);
     }
 
+    /** @testdox prepend() should lazily yield the new value before the source Generator's elements. */
+    public function testPrependReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, 2, 3));
+        $result = Arr\prepend(0)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(0, 1, 2, 3), iterator_to_array($result, false));
+    }
+
+    /** @testdox append() should lazily yield the new value after the source Generator's elements. */
+    public function testAppendReturnsGeneratorForGeneratorInput(): void
+    {
+        $src    = self::gen(array(1, 2, 3));
+        $result = Arr\append(4)($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(1, 2, 3, 4), iterator_to_array($result, false));
+    }
+
+    /** @testdox prepend() over an empty Generator should yield only the new value. */
+    public function testPrependEmptyGeneratorYieldsOnlyTheValue(): void
+    {
+        $result = Arr\prepend('only')(self::gen(array()));
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('only'), iterator_to_array($result, false));
+    }
+
+    /** @testdox append() over an empty Generator should yield only the new value. */
+    public function testAppendEmptyGeneratorYieldsOnlyTheValue(): void
+    {
+        $result = Arr\append('only')(self::gen(array()));
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array('only'), iterator_to_array($result, false));
+    }
 
     public function testCanUseTail()
     {

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -438,6 +438,26 @@ class ArrayFunctionTests extends TestCase
         $this->assertEquals(13, Arr\flattenByN()($array)[12]);
     }
 
+    /** @testdox flattenByN() should return a lazy Generator fully flattening nested arrays in a Generator source when no depth is given. */
+    public function testFlattenByNFullyOverGenerator(): void
+    {
+        $src    = self::gen(array(1, 2, array(3, 4), array(array(5, 6), 7)));
+        $result = Arr\flattenByN()($src);
+
+        $this->assertInstanceOf(\Generator::class, $result);
+        $this->assertSame(array(1, 2, 3, 4, 5, 6, 7), iterator_to_array($result, false));
+    }
+
+    /** @testdox flattenByN() respects depth and skips empty nested arrays on a Generator source. */
+    public function testFlattenByNRespectsDepthOverGenerator(): void
+    {
+        $src    = self::gen(array(1, array(), array(2, array(3, 4)), 5));
+        $result = Arr\flattenByN(1)($src);
+
+        // Empty nested array dropped, depth 1 keeps [3, 4] as a nested array.
+        $this->assertSame(array(1, 2, array(3, 4), 5), iterator_to_array($result, false));
+    }
+
     public function testCanUseReplace()
     {
         $base          = array( 'orange', 'banana', 'apple', 'raspberry' );

--- a/Tests/test-arrays.php
+++ b/Tests/test-arrays.php
@@ -1630,4 +1630,26 @@ class ArrayFunctionTests extends TestCase
         $desc = Arr\usort(fn ($a, $b) => $b - $a);
         $this->assertSame(array(8, 5, 3, 1), $desc($src));
     }
+
+    /** @testdox fold() accepts any iterable and reduces left-to-right via a streaming foreach (no materialisation). */
+    public function testFoldAcceptsGenerator(): void
+    {
+        $sum = Arr\fold(fn ($acc, $v) => $acc + $v, 0);
+        $this->assertSame(15, $sum(self::gen(array(1, 2, 3, 4, 5))));
+    }
+
+    /** @testdox foldR() accepts any iterable and reduces right-to-left (materialises Generator first). */
+    public function testFoldRAcceptsGenerator(): void
+    {
+        // Concatenate right-to-left to prove direction: "c","b","a" → "cba"
+        $cat = Arr\foldR(fn ($acc, $v) => $acc . $v, '');
+        $this->assertSame('cba', $cat(self::gen(array('a', 'b', 'c'))));
+    }
+
+    /** @testdox foldKeys() accepts any iterable and supplies the key to the callback. */
+    public function testFoldKeysAcceptsGenerator(): void
+    {
+        $joined = Arr\foldKeys(fn ($acc, $k, $v) => $acc . "$k=$v;", '');
+        $this->assertSame('a=1;b=2;', $joined(self::gen(array('a' => 1, 'b' => 2))));
+    }
 }

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -699,25 +699,22 @@ function mapWithKey(callable $func): Closure
 }
 
 /**
- * Returns a Closure foreaching over an array
+ * Returns a Closure that iterates over an array or iterable, invoking the
+ * callback with each ($key, $value) pair for its side effect.
  *
  * @param callable(int|string $key, mixed $value):void $func
- * @return Closure(mixed[]):void
+ * @return Closure(iterable<int|string, mixed>):void
  */
 function each(callable $func): Closure
 {
     /**
-     * @param mixed[] $array The array to map
+     * @param iterable<int|string, mixed> $source
      * @return void
      */
-    return function (array $array) use ($func): void {
-        array_map(
-            function ($key, $value) use ($func) {
-                $func($key, $value);
-            },
-            array_keys($array),
-            $array
-        );
+    return function (iterable $source) use ($func): void {
+        foreach ($source as $key => $value) {
+            $func($key, $value);
+        }
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -363,19 +363,21 @@ function filterOr(callable ...$callables): Closure
 }
 
 /**
- * Creates a Closure for running array filter and getting the first value.
+ * Creates a Closure that returns the first element matching a predicate.
+ * Accepts any iterable; short-circuits on the first match (the source is NOT
+ * advanced past it).
  *
  * @param callable $func
- * @return Closure(array<int|string, mixed>):?mixed
+ * @return Closure(iterable<int|string, mixed>):?mixed
  */
 function filterFirst(callable $func): Closure
 {
     /**
-     * @param array<int|string, mixed> $array The array to filter
-     * @return mixed|null The first element from the filtered array or null if filter returns empty
+     * @param iterable<int|string, mixed> $source The array or iterable to filter.
+     * @return mixed|null The first matching value, or null if no match found.
      */
-    return function (array $array) use ($func) {
-        foreach ($array as $value) {
+    return function (iterable $source) use ($func) {
+        foreach ($source as $value) {
             $result = $func($value);
             if (\is_bool($result) && $result) {
                 return $value;
@@ -488,19 +490,20 @@ function partition(callable $function): Closure
 }
 
 /**
- * Returns a closure for checking all elements pass a filter.
+ * Returns a closure for checking that every element of an array or iterable
+ * passes the predicate. Short-circuits on the first non-matching value.
  *
  * @param callable(mixed):bool $function
- * @return Closure(mixed[]):bool
+ * @return Closure(iterable<int|string, mixed>):bool
  */
 function filterAll(callable $function): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return bool
      */
-    return function (array $array) use ($function): bool {
-        foreach ($array as $value) {
+    return function (iterable $source) use ($function): bool {
+        foreach ($source as $value) {
             if (false === $function($value)) {
                 return false;
             }
@@ -511,19 +514,20 @@ function filterAll(callable $function): Closure
 
 
 /**
- * Returns a closure for checking any elements pass a filter.
+ * Returns a closure for checking that at least one element of an array or
+ * iterable passes the predicate. Short-circuits on the first match.
  *
  * @param callable(mixed):bool $function
- * @return Closure(mixed[]):bool
+ * @return Closure(iterable<int|string, mixed>):bool
  */
 function filterAny(callable $function): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return bool
      */
-    return function (array $array) use ($function): bool {
-        foreach ($array as $value) {
+    return function (iterable $source) use ($function): bool {
+        foreach ($source as $value) {
             if (true === $function($value)) {
                 return true;
             }
@@ -1271,25 +1275,43 @@ function foldKeys(callable $callable, $initial = array()): Closure
 }
 
 /**
- * Creates a function which takes the first n elements from an array
+ * Creates a function which takes the first n elements from an array or iterable.
+ *
+ * - Array in  → array of the first $count elements (unchanged behaviour).
+ * - Generator/Traversable in → Generator that yields up to $count elements
+ *   lazily. The source is NOT advanced beyond what was taken.
  *
  * @param int $count
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  * @throws \InvalidArgumentException if count is negative
  */
 function take(int $count = 1): Closure
 {
-    // throw InvalidArgumentException if count is negative
     if ($count < 0) {
         throw new \InvalidArgumentException(__FUNCTION__ . ' count must be greater than or equal to 0');
     }
 
     /**
-     * @param mixed[] $array
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($count) {
-        return \array_slice($array, 0, $count);
+    return function (iterable $source) use ($count) {
+        if (is_array($source)) {
+            return \array_slice($source, 0, $count);
+        }
+        return (function () use ($source, $count) {
+            if ($count === 0) {
+                return;
+            }
+            $taken = 0;
+            foreach ($source as $key => $value) {
+                yield $key => $value;
+                $taken++;
+                if ($taken >= $count) {
+                    break;
+                }
+            }
+        })();
     };
 }
 
@@ -1324,52 +1346,80 @@ function takeLast(int $count = 1): Closure
 }
 
 /**
- * Creates a function that allows you to take a slice of an array until the passed conditional
- * returns true.
+ * Creates a function that takes elements from an array or iterable until the
+ * conditional returns true (exclusive — the first truthy element is NOT included).
+ *
+ * - Array in  → array out (unchanged behaviour).
+ * - Generator/Traversable in → Generator out, yields lazily, stops at the first
+ *   truthy predicate. Source is not advanced past the stopping element.
  *
  * @param callable(mixed): bool $conditional
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function takeUntil(callable $conditional): Closure
 {
     /**
-     * @param mixed[] $array
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($conditional) {
-        $carry = array();
-        foreach ($array as $key => $value) {
-            if (true === $conditional($value)) {
-                break;
+    return function (iterable $source) use ($conditional) {
+        if (is_array($source)) {
+            $carry = array();
+            foreach ($source as $key => $value) {
+                if (true === $conditional($value)) {
+                    break;
+                }
+                $carry[$key] = $value;
             }
-            $carry[$key] = $value;
+            return $carry;
         }
-        return $carry;
+        return (function () use ($source, $conditional) {
+            foreach ($source as $key => $value) {
+                if (true === $conditional($value)) {
+                    break;
+                }
+                yield $key => $value;
+            }
+        })();
     };
 }
 
 /**
- * Creates a function that allows you to take a slice of an array until the passed conditional
- * returns false.
+ * Creates a function that takes elements from an array or iterable while the
+ * conditional returns true. Stops at the first falsy predicate (exclusive).
+ *
+ * - Array in  → array out (unchanged behaviour).
+ * - Generator/Traversable in → Generator out, yields lazily, stops at the first
+ *   falsy predicate. Source is not advanced past the stopping element.
  *
  * @param callable(mixed): bool $conditional
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function takeWhile(callable $conditional): Closure
 {
     /**
-     * @param mixed[] $array
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($conditional) {
-        $carry = array();
-        foreach ($array as $key => $value) {
-            if (false === $conditional($value)) {
-                break;
+    return function (iterable $source) use ($conditional) {
+        if (is_array($source)) {
+            $carry = array();
+            foreach ($source as $key => $value) {
+                if (false === $conditional($value)) {
+                    break;
+                }
+                $carry[$key] = $value;
             }
-            $carry[$key] = $value;
+            return $carry;
         }
-        return $carry;
+        return (function () use ($source, $conditional) {
+            foreach ($source as $key => $value) {
+                if (false === $conditional($value)) {
+                    break;
+                }
+                yield $key => $value;
+            }
+        })();
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -1293,40 +1293,81 @@ function usort(callable $function): Closure
 
 
 /**
- * Returns a Closure for applying a function to every element of an array
+ * Returns a Closure for a left-scan (running fold) over an array or iterable.
+ * Emits the initial value, then every intermediate accumulation.
+ *
+ * - Array in  → array out (unchanged behaviour).
+ * - Generator/Traversable in → Generator out that yields the initial value
+ *   first, then each running accumulation lazily.
  *
  * @param callable(mixed $carry, mixed $value):mixed $function
  * @param mixed $initialValue
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):(array<int, mixed>|\Generator<int, mixed>)
  */
 function scan(callable $function, $initialValue): Closure
 {
-    return function (array $array) use ($function, $initialValue) {
-        $carry[] = $initialValue;
-        foreach ($array as $key => $value) {
-            $initialValue = $function($initialValue, $value);
-            $carry[]      = $initialValue;
+    /**
+     * @param iterable<int|string, mixed> $source
+     * @return array<int, mixed>|\Generator<int, mixed>
+     */
+    return function (iterable $source) use ($function, $initialValue) {
+        if (is_array($source)) {
+            $carry[] = $initialValue;
+            foreach ($source as $key => $value) {
+                $initialValue = $function($initialValue, $value);
+                $carry[]      = $initialValue;
+            }
+            return $carry;
         }
-        return $carry;
+        return (function () use ($source, $function, $initialValue) {
+            yield $initialValue;
+            foreach ($source as $value) {
+                $initialValue = $function($initialValue, $value);
+                yield $initialValue;
+            }
+        })();
     };
 }
 
 /**
- * Returns a Closure for applying a function to every element of an array
+ * Returns a Closure for a right-scan (running fold from the right) over an array
+ * or iterable. Emits every intermediate accumulation, finishing with the initial.
+ *
+ * - Array in  → array out (unchanged behaviour).
+ * - Generator/Traversable in → the source is materialised to an array (reverse
+ *   scan requires it), the scan is computed, then the results are re-yielded
+ *   as a Generator for API consistency.
  *
  * @param callable(mixed $carry, mixed $value):mixed $function
  * @param mixed $initialValue
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):(array<int, mixed>|\Generator<int, mixed>)
  */
 function scanR(callable $function, $initialValue): Closure
 {
-    return function (array $array) use ($function, $initialValue) {
-        $carry[] = $initialValue;
-        foreach (array_reverse($array) as $key => $value) {
-            $initialValue = $function($initialValue, $value);
-            $carry[]      = $initialValue;
+    /**
+     * @param iterable<int|string, mixed> $source
+     * @return array<int, mixed>|\Generator<int, mixed>
+     */
+    return function (iterable $source) use ($function, $initialValue) {
+        if (is_array($source)) {
+            $carry[] = $initialValue;
+            foreach (array_reverse($source) as $key => $value) {
+                $initialValue = $function($initialValue, $value);
+                $carry[]      = $initialValue;
+            }
+            return \array_reverse($carry);
         }
-        return \array_reverse($carry);
+        return (function () use ($source, $function, $initialValue) {
+            $materialised = iterator_to_array($source);
+            $carry        = array($initialValue);
+            foreach (array_reverse($materialised) as $value) {
+                $initialValue = $function($initialValue, $value);
+                $carry[]      = $initialValue;
+            }
+            foreach (array_reverse($carry) as $v) {
+                yield $v;
+            }
+        })();
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -167,19 +167,20 @@ function tail(iterable $source)
 
 
 /**
- * Creates a Closure for concatenating arrays with a defined glue.
+ * Creates a Closure for joining an array or iterable into a string with a glue.
+ * Terminal: Generator input is materialised before joining.
  *
  * @param string|null $glue The string to join each element. If null, will be no separation between elements.
- * @return Closure(array<int|string, mixed>):string
- *
+ * @return Closure(iterable<int|string, mixed>):string
  */
 function toString(?string $glue = null): Closure
 {
     /**
-     * @param array<int|string, mixed> $array Array join
+     * @param iterable<int|string, mixed> $source
      * @return string
      */
-    return function (array $array) use ($glue): string {
+    return function (iterable $source) use ($glue): string {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return $glue ? \join($glue, $array) : \join($array);
     };
 }
@@ -403,18 +404,21 @@ function filterFirst(callable $func): Closure
 }
 
 /**
- * Creates a Closure for running array filter and getting the last value.
+ * Creates a Closure that returns the last element matching a predicate.
+ * Accepts any iterable. Terminal — for a Generator, the whole source is
+ * consumed (there is no way to find "last" without doing so).
  *
  * @param callable $func
- * @return Closure(array<int|string, mixed>):?mixed
+ * @return Closure(iterable<int|string, mixed>):?mixed
  */
 function filterLast(callable $func): Closure
 {
     /**
-     * @param array<int|string, mixed> $array The array to filter
-     * @return mixed|null The last element from the filtered array.
+     * @param iterable<int|string, mixed> $source The array or iterable to scan.
+     * @return mixed|null The last matching value, or null if no match.
      */
-    return function (array $array) use ($func) {
+    return function (iterable $source) use ($func) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         while ($value = array_pop($array)) {
             $result = $func($value);
             if (\is_bool($result) && $result) {
@@ -455,37 +459,41 @@ function filterMap(callable $filter, callable $map): Closure
 }
 
 /**
- * Runs an array through a filters, returns the total count of true
+ * Returns a Closure that counts the elements of an array or iterable matching
+ * a predicate. Terminal — Generator input is consumed.
  *
  * @param callable $function
- * @return Closure(array<int|string, mixed>):int
+ * @return Closure(iterable<int|string, mixed>):int
  */
 function filterCount(callable $function): Closure
 {
     /**
-     * @param array<int|string, mixed> $array
+     * @param iterable<int|string, mixed> $source
      * @return int Count
      */
-    return function (array $array) use ($function) {
+    return function (iterable $source) use ($function) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return count(array_filter($array, $function));
     };
 }
 
 /**
- * Returns a Closure for partitioning an array based
- * on the results of a filter type function.
- * Callable will be cast to a bool, if truthy will be listed under 1 key, else 0 for falsey
+ * Returns a Closure for partitioning an array or iterable into two buckets by
+ * a predicate. Terminal — Generator input is consumed fully.
+ *
+ * Callable will be cast to a bool, if truthy will be listed under key 1, else 0.
  *
  * @param callable(mixed):(bool|int) $function
- * @return Closure(mixed[]):array{0:mixed[], 1:mixed[]}
+ * @return Closure(iterable<int|string, mixed>):array{0:mixed[], 1:mixed[]}
  */
 function partition(callable $function): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return array{0:mixed[], 1:mixed[]}
      */
-    return function (array $array) use ($function): array {
+    return function (iterable $source) use ($function): array {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         /** @var array{0:mixed[], 1:mixed[]} $result */
         $result = array_reduce(
             $array,
@@ -781,18 +789,20 @@ function flatMap(callable $function, ?int $n = null): Closure
 
 
 /**
- * Creates a Closure for grouping an array.
+ * Creates a Closure for grouping an array or iterable by a key-producing fn.
+ * Terminal — Generator input is consumed fully.
  *
  * @param callable(mixed):(string|int) $function The function to group by.
- * @return Closure(mixed):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function groupBy(callable $function): Closure
 {
     /**
-     * @param mixed[] $array The array to be grouped
+     * @param iterable<int|string, mixed> $source The array or iterable to be grouped.
      * @return mixed[] Grouped array.
      */
-    return function (array $array) use ($function): array {
+    return function (iterable $source) use ($function): array {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return array_reduce(
             $array,
             /**
@@ -962,64 +972,70 @@ function flattenByN(?int $n = null): Closure
 }
 
 /**
- * Returns a closure for recursively changing values in an array.
+ * Returns a closure for recursively replacing values in an array or iterable.
+ * Terminal — Generator input is materialised first.
  *
  * @param mixed[] ...$with The array values to replace with
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function replaceRecursive(array ...$with): Closure
 {
     /**
-     * @param mixed[] $array The array to have elements replaced from.
+     * @param iterable<int|string, mixed> $source
      * @return mixed[] Array with replacements.
      */
-    return function (array $array) use ($with): array {
+    return function (iterable $source) use ($with): array {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return array_replace_recursive($array, ...$with);
     };
 }
 
 /**
- * Returns a Closure for changing all values in a flat array, based on key.
+ * Returns a Closure for changing values in a flat array or iterable, based on key.
+ * Terminal — Generator input is materialised first.
  *
  * @param mixed[] ...$with Array with values to replace with, must have matching key with base array.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function replace(array ...$with): Closure
 {
     /**
-     * @param mixed[] $array The array to have elements replaced from.
+     * @param iterable<int|string, mixed> $source
      * @return mixed[] Array with replacements.
      */
-    return function (array $array) use ($with): array {
+    return function (iterable $source) use ($with): array {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return array_replace($array, ...$with);
     };
 }
 
 /**
- * Returns a Closure for doing array_sum with the results of a function/expression.
+ * Returns a Closure for summing the result of a callback applied to each element
+ * of an array or iterable. Terminal — Generator input is materialised.
  *
- * @param callable(mixed):Number $function The function to return the value for array sum
- * @return Closure(mixed[]):Number
+ * @param callable(mixed):Number $function Applied to each value before summing.
+ * @return Closure(iterable<int|string, mixed>):Number
  */
 function sumWhere(callable $function): Closure
 {
     /**
-     * @param mixed[] $array Array to do sum() on.
+     * @param iterable<int|string, mixed> $source
      * @return Number The total.
      */
-    return function (array $array) use ($function) {
+    return function (iterable $source) use ($function) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return array_sum(array_map($function, $array));
     };
 }
 
 /**
- * Creates a closure for casting an array to an object.
- * Assumed all properties are public
- * None existing properties will be set as dynamic properties.
+ * Creates a closure for casting an array or iterable into an object.
+ * Assumes all properties are public; non-existing properties are set dynamically.
+ * Terminal — Generator input is materialised first.
  *
- * @param object|null $object The object to cast to, defaults to stdClass
+ * @param object|null $object The object to cast to, defaults to stdClass.
  * @phpstan-param mixed $object
- * @return Closure(mixed[]):object
+ * @return Closure(iterable<int|string, mixed>):object
  * @throws \InvalidArgumentException If property does not exist or is not public.
  */
 function toObject($object = null): Closure
@@ -1032,10 +1048,11 @@ function toObject($object = null): Closure
     }
 
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return object
      */
-    return function (array $array) use ($object) {
+    return function (iterable $source) use ($object) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         foreach ($array as $key => $value) {
             // If key is not a string or numerical, skip it.
             if (!is_string($key) || is_numeric($key)) {
@@ -1468,10 +1485,12 @@ function take(int $count = 1): Closure
 }
 
 /**
- * Creates a function which takes the last n elements from an array
+ * Creates a function which takes the last N elements from an array or iterable.
+ * Terminal — Generator input is materialised fully (the last N is only
+ * knowable once the source has been consumed).
  *
  * @param int $count
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  * @throws \InvalidArgumentException if count is negative
  */
 function takeLast(int $count = 1): Closure
@@ -1481,18 +1500,19 @@ function takeLast(int $count = 1): Closure
         throw new \InvalidArgumentException(__FUNCTION__ . ' count must be greater than or equal to 0');
     }
 
-    // If count is 0, return an empty array
+    // If count is 0, return an empty array for any input.
     if ($count === 0) {
-        return function (array $array) {
+        return function (iterable $source) {
             return array();
         };
     }
 
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return mixed[]
      */
-    return function (array $array) use ($count) {
+    return function (iterable $source) use ($count) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return \array_slice($array, -$count);
     };
 }
@@ -1576,18 +1596,20 @@ function takeWhile(callable $conditional): Closure
 }
 
 /**
- * Picks selected indexes from an array
+ * Picks selected indexes from an array or iterable.
+ * Terminal — Generator input is materialised first.
  *
  * @param string ...$indexes
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function pick(string ...$indexes): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return mixed[]
      */
-    return function (array $array) use ($indexes) {
+    return function (iterable $source) use ($indexes) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return array_intersect_key($array, array_flip($indexes));
     };
 }

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -1102,38 +1102,40 @@ function toJson(int $flags = 0, int $depth = 512): Closure
 
 
 /**
- * Returns a Closure for doing regular SORT against an array.
- * Doesn't maintain keys.
+ * Returns a Closure for doing regular SORT against an array or iterable.
+ * Doesn't maintain keys. Terminal — Generator input is materialised.
  *
  * @param int $flag Uses php stock sort constants or numerical values.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function sort(int $flag = SORT_REGULAR): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($flag) {
+    return function (iterable $source) use ($flag) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \sort($array, $flag);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for doing regular Reverse SORT against an array.
- * Doesn't maintain keys.
+ * Returns a Closure for doing regular Reverse SORT against an array or iterable.
+ * Doesn't maintain keys. Terminal — Generator input is materialised.
  *
  * @param int $flag Uses php stock sort constants or numerical values.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function rsort(int $flag = SORT_REGULAR): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($flag) {
+    return function (iterable $source) use ($flag) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \rsort($array, $flag);
         return $array;
     };
@@ -1141,145 +1143,158 @@ function rsort(int $flag = SORT_REGULAR): Closure
 
 
 /**
- * Returns a Closure for sorting an array by key in ascending order.
+ * Returns a Closure for sorting an array or iterable by key in ascending order.
+ * Terminal — Generator input is materialised.
  *
  * @param int $flag Uses php stock sort constants or numerical values.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function ksort(int $flag = SORT_REGULAR): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($flag) {
+    return function (iterable $source) use ($flag) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \ksort($array, $flag);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array by key in descending (reverse) order.
+ * Returns a Closure for sorting an array or iterable by key in descending order.
+ * Terminal — Generator input is materialised.
  *
  * @param int $flag Uses php stock sort constants or numerical values.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function krsort(int $flag = SORT_REGULAR): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($flag) {
+    return function (iterable $source) use ($flag) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \krsort($array, $flag);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array by value in ascending order.
- * Maintain keys.
+ * Returns a Closure for sorting an array or iterable by value in ascending order.
+ * Maintains keys. Terminal — Generator input is materialised.
  *
  * @param int $flag Uses php stock sort constants or numerical values.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function asort(int $flag = SORT_REGULAR): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($flag) {
+    return function (iterable $source) use ($flag) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \asort($array, $flag);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array by value in descending (reverse) order.
- * Maintain keys.
+ * Returns a Closure for sorting an array or iterable by value in descending order.
+ * Maintains keys. Terminal — Generator input is materialised.
  *
  * @param int $flag Uses php stock sort constants or numerical values.
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function arsort(int $flag = SORT_REGULAR): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($flag) {
+    return function (iterable $source) use ($flag) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \arsort($array, $flag);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array using a "natural order" algorithm
+ * Returns a Closure for sorting an array or iterable with a "natural order" algorithm.
+ * Terminal — Generator input is materialised.
  *
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function natsort(): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) {
+    return function (iterable $source) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \natsort($array);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array using a case insensitive "natural order" algorithm
+ * Returns a Closure for sorting an array or iterable with a case-insensitive
+ * "natural order" algorithm. Terminal — Generator input is materialised.
  *
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function natcasesort(): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) {
+    return function (iterable $source) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \natcasesort($array);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array by key using a custom comparison function
+ * Returns a Closure for sorting an array or iterable by key using a custom comparator.
+ * Terminal — Generator input is materialised.
  *
  * @param callable(mixed $a, mixed $b): int $function
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function uksort(callable $function): Closure
 {
     /**
-     *  @param mixed[] $array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($function) {
+    return function (iterable $source) use ($function) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \uksort($array, $function);
         return $array;
     };
 }
 
 /**
- * Returns a Closure for sorting an array using a custom comparison function
- * Maintain keys.
+ * Returns a Closure for sorting an array or iterable by value using a custom
+ * comparator. Maintains keys. Terminal — Generator input is materialised.
  *
  * @param callable(mixed $a, mixed $b): int $function
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function uasort(callable $function): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($function) {
+    return function (iterable $source) use ($function) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \uasort($array, $function);
         return $array;
     };
@@ -1287,19 +1302,20 @@ function uasort(callable $function): Closure
 
 
 /**
- * Returns a Closure for sorting an array using a custom comparison function
- * Doesn't maintain keys.
+ * Returns a Closure for sorting an array or iterable using a custom comparator.
+ * Does not maintain keys. Terminal — Generator input is materialised.
  *
  * @param callable(mixed $a, mixed $b): int $function
- * @return Closure(mixed[]):mixed[]
+ * @return Closure(iterable<int|string, mixed>):mixed[]
  */
 function usort(callable $function): Closure
 {
     /**
-     *  @param mixed[]$array The array to sort
-     *  @return mixed[] The sorted array (new array)
+     * @param iterable<int|string, mixed> $source
+     * @return mixed[] The sorted array (new array).
      */
-    return function (array $array) use ($function) {
+    return function (iterable $source) use ($function) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         \usort($array, $function);
         return $array;
     };

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -754,9 +754,6 @@ function flatMap(callable $function, ?int $n = null): Closure
                  */
                 function (array $carry, $element) use ($n, $function): array {
                     if (is_array($element) && (is_null($n) || $n > 0)) {
-                        // Recursive call on an array element always hits the array path,
-                        // which returns array. The return type is widened to include
-                        // Generator for iterable inputs; narrow it back here for array_merge.
                         $recursed = flatMap($function, $n ? $n - 1 : null)($element);
                         $carry    = array_merge($carry, is_array($recursed) ? $recursed : iterator_to_array($recursed));
                     } else {
@@ -939,14 +936,10 @@ function flattenByN(?int $n = null): Closure
                     if (is_array($element) && empty($element)) {
                         return $carry;
                     }
-                    // If the element is an array and we are still flattening, call again
                     if (is_array($element) && (is_null($n) || $n > 0)) { // @phpstan-ignore-line
-                        // Recursion on an array hits the array path; narrow the widened
-                        // array|Generator return back to array for array_merge.
                         $recursed = flattenByN($n ? $n - 1 : null)($element);
                         $carry    = array_merge($carry, is_array($recursed) ? $recursed : iterator_to_array($recursed));
                     } else {
-                        // Else just add the element.
                         $carry[] = $element;
                     }
                     return $carry;

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -1402,57 +1402,69 @@ function scanR(callable $function, $initialValue): Closure
 }
 
 /**
- * Creates a function for defining the callback and initial for reduce/fold
+ * Creates a Closure that reduces an array or iterable left-to-right with an
+ * initial accumulator. Terminal — Generator input is consumed fully via a
+ * streaming foreach (no materialisation).
  *
  * @param callable(mixed $carry, mixed $value): mixed $callable
  * @param mixed $initial
- * @return Closure(mixed[]):mixed
+ * @return Closure(iterable<int|string, mixed>):mixed
  */
 function fold(callable $callable, $initial = array()): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return mixed
      */
-    return function (array $array) use ($callable, $initial) {
-        return array_reduce($array, $callable, $initial);
+    return function (iterable $source) use ($callable, $initial) {
+        if (is_array($source)) {
+            return array_reduce($source, $callable, $initial);
+        }
+        foreach ($source as $value) {
+            $initial = $callable($initial, $value);
+        }
+        return $initial;
     };
 }
 
 /**
- * Creates a function for defining the callback and initial for reduce/fold
+ * Creates a Closure that reduces an array or iterable right-to-left with an
+ * initial accumulator. Terminal — Generator input must be materialised to
+ * reverse before reducing.
  *
  * @param callable(mixed $carry, mixed $value): mixed $callable
  * @param mixed $initial
- * @return Closure(mixed[]):mixed
+ * @return Closure(iterable<int|string, mixed>):mixed
  */
 function foldR(callable $callable, $initial = array()): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return mixed
      */
-    return function (array $array) use ($callable, $initial) {
+    return function (iterable $source) use ($callable, $initial) {
+        $array = is_array($source) ? $source : iterator_to_array($source);
         return array_reduce(\array_reverse($array), $callable, $initial);
     };
 }
 
 /**
- * Creates a function for defining the callback and initial for reduce/fold, with the key
- * also passed to the callback.
+ * Creates a Closure that reduces an array or iterable left-to-right with the
+ * key passed to the callback alongside the value. Terminal — streams the
+ * source via foreach (no materialisation needed).
  *
  * @param callable(mixed $carry, int|string $key, mixed $value): mixed $callable
  * @param mixed $initial
- * @return Closure(mixed[]):mixed
+ * @return Closure(iterable<int|string, mixed>):mixed
  */
 function foldKeys(callable $callable, $initial = array()): Closure
 {
     /**
-     * @param mixed[] $array
+     * @param iterable<int|string, mixed> $source
      * @return mixed
      */
-    return function (array $array) use ($callable, $initial) {
-        foreach ($array as $key => $value) {
+    return function (iterable $source) use ($callable, $initial) {
+        foreach ($source as $key => $value) {
             $initial = $callable($initial, $key, $value);
         }
         return $initial;

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -949,16 +949,18 @@ function flattenByN(?int $n = null): Closure
         }
         return (function () use ($source, $n) {
             foreach ($source as $element) {
-                if (is_array($element) && empty($element)) {
-                    continue;
-                }
-                if (is_array($element) && (is_null($n) || $n > 0)) { // @phpstan-ignore-line
-                    foreach (flattenByN($n ? $n - 1 : null)($element) as $sub) {
-                        yield $sub;
+                if (is_array($element)) {
+                    if (empty($element)) {
+                        continue;
                     }
-                } else {
-                    yield $element;
+                    if (is_null($n) || $n > 0) {
+                        foreach (flattenByN($n ? $n - 1 : null)($element) as $sub) {
+                            yield $sub;
+                        }
+                        continue;
+                    }
                 }
+                yield $element;
             }
         })();
     };

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -35,38 +35,62 @@ use stdClass;
 use PinkCrab\FunctionConstructors\Comparisons as Comp;
 
 /**
- * Returns a Closure for appending a value to an array.
+ * Returns a Closure for appending a value to the end of an array or iterable.
+ *
+ * - Array in  → array out with the value pushed on the end (unchanged behaviour).
+ * - Generator/Traversable in → Generator out that first yields every source
+ *   element, then yields the new value.
  *
  * @param mixed $value
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function append($value): Closure
 {
     /**
-     * @param array<int|string, mixed> $array
-     * @return array<int|string, mixed>
+     * @param iterable<int|string, mixed> $source
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($value): array {
-        $array[] = $value;
-        return $array;
+    return function (iterable $source) use ($value) {
+        if (is_array($source)) {
+            $source[] = $value;
+            return $source;
+        }
+        return (function () use ($source, $value) {
+            foreach ($source as $key => $v) {
+                yield $key => $v;
+            }
+            yield $value;
+        })();
     };
 }
 
 /**
- * Returns a Closure for prepending a value to an array.
+ * Returns a Closure for prepending a value to the start of an array or iterable.
+ *
+ * - Array in  → array out with the value unshifted onto the front (unchanged behaviour).
+ * - Generator/Traversable in → Generator out that first yields the new value, then
+ *   yields every source element.
  *
  * @param mixed $value
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function prepend($value): Closure
 {
     /**
-     * @param array<int|string, mixed> $array
-     * @return array<int|string, mixed>
+     * @param iterable<int|string, mixed> $source
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($value): array {
-        array_unshift($array, $value);
-        return $array;
+    return function (iterable $source) use ($value) {
+        if (is_array($source)) {
+            array_unshift($source, $value);
+            return $source;
+        }
+        return (function () use ($source, $value) {
+            yield $value;
+            foreach ($source as $key => $v) {
+                yield $key => $v;
+            }
+        })();
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -95,43 +95,74 @@ function prepend($value): Closure
 }
 
 /**
- * Gets the first value from an array.
+ * Gets the first value from an array or iterable. For Generators this is a
+ * genuine early-exit — the rest of the stream is NOT consumed.
  *
- * @param array<int|string, mixed> $array The array.
- * @return mixed Will return the first value is array is not empty, else null.
+ * @param iterable<int|string, mixed> $source The array or iterable.
+ * @return mixed The first value, or null if empty.
  */
-function head(array $array)
+function head(iterable $source)
 {
-    return !empty($array) ? array_values($array)[0] : null;
-}
-
-/**
- * Gets the last value from an array.
- *
- * @param array<int|string, mixed> $array The array.
- * @return mixed Will return the last value is array is not empty, else null.
- */
-function last(array $array)
-{
-    return !empty($array) ? array_reverse($array, false)[0] : null;
-}
-
-/**
- * Gets the remainder values from an array, after first item removed.
- *
- * @param array<int|string, mixed> $array
- * @return array<int|string, mixed>|null Will return the first value is array is not empty, else null.
- */
-function tail(array $array)
-{
-    // Return null if empty.
-    if (empty($array)) {
-        return null;
+    if (is_array($source)) {
+        return ! empty($source) ? array_values($source)[0] : null;
     }
+    foreach ($source as $value) {
+        return $value;
+    }
+    return null;
+}
 
-    // Remove the first item from the array.
-    array_shift($array);
-    return $array;
+/**
+ * Gets the last value from an array or iterable. For a Generator the whole
+ * stream is consumed (there is no way to know the last value without doing so).
+ *
+ * @param iterable<int|string, mixed> $source The array or iterable.
+ * @return mixed The last value, or null if empty.
+ */
+function last(iterable $source)
+{
+    if (is_array($source)) {
+        return ! empty($source) ? array_reverse($source, false)[0] : null;
+    }
+    $last  = null;
+    $found = false;
+    foreach ($source as $value) {
+        $last  = $value;
+        $found = true;
+    }
+    return $found ? $last : null;
+}
+
+/**
+ * Gets the remainder of an array or iterable after the first element is removed.
+ *
+ * - Array in  → new array with the first element dropped, or null if empty (unchanged behaviour).
+ * - Generator/Traversable in → Generator that lazily yields every element after
+ *   the first. For an empty Generator source the returned Generator is empty
+ *   (NOT null — this is the one documented API divergence from the array path).
+ *
+ * @param iterable<int|string, mixed> $source
+ * @return array<int|string, mixed>|\Generator<int|string, mixed>|null
+ */
+function tail(iterable $source)
+{
+    if (is_array($source)) {
+        if (empty($source)) {
+            return null;
+        }
+        array_shift($source);
+        return $source;
+    }
+    return (function () use ($source) {
+        $first = true;
+        foreach ($source as $key => $value) {
+            if ($first) {
+                $first = false;
+                continue;
+            }
+            yield $key => $value;
+        }
+    })();
 }
 
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -220,73 +220,91 @@ function arrayCompilerTyped(callable $validator, array $inital = array()): Closu
 
 
 /**
- * Created a Closure for filtering an array.
+ * Created a Closure for filtering an array or iterable.
  *
- * @param callable $callable The function to apply to the array.
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; keys preserved).
+ *
+ * @param callable $callable The function to apply to each value.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function filter(callable $callable): Closure
 {
     /**
-     * @param array<int|string, mixed> $source Array to filter
-     * @return array<int|string, mixed> Filtered array.
+     * @param iterable<int|string, mixed> $source Array or iterable to filter.
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $source) use ($callable): array {
-        return array_filter($source, $callable);
+    return function (iterable $source) use ($callable) {
+        if (is_array($source)) {
+            return array_filter($source, $callable);
+        }
+        return (function () use ($source, $callable) {
+            foreach ($source as $key => $value) {
+                if ($callable($value)) {
+                    yield $key => $value;
+                }
+            }
+        })();
     };
 }
 
 /**
- * Create a Closure for filtering an array by a key.
+ * Create a Closure for filtering an array or iterable by its keys.
  *
- * @param callable $callable The function to apply to the array.
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; keys preserved).
+ *
+ * @param callable $callable The function to apply to each key.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function filterKey(callable $callable): Closure
 {
     /**
-     * @param array<int|string, mixed> $source Array to filter
-     * @return array<int|string, mixed> Filtered array.
+     * @param iterable<int|string, mixed> $source Array or iterable to filter.
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $source) use ($callable): array {
-        return array_filter($source, $callable, \ARRAY_FILTER_USE_KEY);
+    return function (iterable $source) use ($callable) {
+        if (is_array($source)) {
+            return array_filter($source, $callable, \ARRAY_FILTER_USE_KEY);
+        }
+        return (function () use ($source, $callable) {
+            foreach ($source as $key => $value) {
+                if ($callable($key)) {
+                    yield $key => $value;
+                }
+            }
+        })();
     };
 }
 
 /**
- * Creates a Closure for running an array through various callbacks for all true response.
- * Wrapper for creating a AND group of callbacks and running through array filter.
+ * Creates a Closure applying an AND group of predicates.
+ *
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; keys preserved).
  *
  * @param callable ...$callables
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function filterAnd(callable ...$callables): Closure
 {
-    /**
-     * @param array<int|string, mixed> $source Array to filter
-     * @return array<int|string, mixed> Filtered array.
-     */
-    return function (array $source) use ($callables): array {
-        return array_filter($source, Comp\groupAnd(...$callables));
-    };
+    $predicate = Comp\groupAnd(...$callables);
+    return filter($predicate);
 }
 
 /**
- * Creates a Closure for running an array through various callbacks for any true response.
- * Wrapper for creating a OR group of callbacks and running through array filter.
+ * Creates a Closure applying an OR group of predicates.
+ *
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; keys preserved).
  *
  * @param callable ...$callables
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function filterOr(callable ...$callables): Closure
 {
-    /**
-     * @param array<int|string, mixed> $source Array to filter
-     * @return array<int|string, mixed> Filtered array.
-     */
-    return function (array $source) use ($callables): array {
-        return array_filter($source, Comp\groupOr(...$callables));
-    };
+    $predicate = Comp\groupOr(...$callables);
+    return filter($predicate);
 }
 
 /**
@@ -334,22 +352,32 @@ function filterLast(callable $func): Closure
 }
 
 /**
- * Creates a Closure which takes an array, applies a filter, then maps the
- * results of the map.
+ * Creates a Closure which filters then maps over the results.
  *
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; keys preserved).
  *
- * @param callable(mixed):bool $filter Function to of filter contents
- * @param callable(mixed):mixed $map Function to map results of filter function.
- * @return Closure(array<int|string, mixed>):array<int|string, mixed>
+ * @param callable(mixed):bool $filter Predicate used to include values.
+ * @param callable(mixed):mixed $map Transformation applied to included values.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function filterMap(callable $filter, callable $map): Closure
 {
     /**
-     * @param array<int|string, mixed> $array The array to filter then map.
-     * @return array<int|string, mixed>
+     * @param iterable<int|string, mixed> $source Array or iterable to filter+map.
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($filter, $map): array {
-        return array_map($map, array_filter($array, $filter));
+    return function (iterable $source) use ($filter, $map) {
+        if (is_array($source)) {
+            return array_map($map, array_filter($source, $filter));
+        }
+        return (function () use ($source, $filter, $map) {
+            foreach ($source as $key => $value) {
+                if ($filter($value)) {
+                    yield $key => $map($value);
+                }
+            }
+        })();
     };
 }
 
@@ -488,73 +516,110 @@ function map(callable $func): Closure
 }
 
 /**
- * Returns a Closure for mapping of an arrays keys.
+ * Returns a Closure for transforming the keys of an array or iterable.
  * Setting the key to an existing index will overwrite the current value at same index.
  *
- * @param callable $func
- * @return Closure(mixed[]):mixed[]
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; transformed keys preserved).
+ *
+ * @param callable $func Callback applied to each key.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function mapKey(callable $func): Closure
 {
     /**
-     * @param mixed[] $array The array to map
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source Array or iterable whose keys are transformed.
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($func): array {
-        return array_reduce(
-            array_keys($array),
-            function ($carry, $key) use ($func, $array) {
-                $carry[$func($key)] = $array[$key];
-                return $carry;
-            },
-            array()
-        );
+    return function (iterable $source) use ($func) {
+        if (is_array($source)) {
+            return array_reduce(
+                array_keys($source),
+                function ($carry, $key) use ($func, $source) {
+                    $carry[$func($key)] = $source[$key];
+                    return $carry;
+                },
+                array()
+            );
+        }
+        return (function () use ($source, $func) {
+            foreach ($source as $key => $value) {
+                yield $func($key) => $value;
+            }
+        })();
     };
 }
 
 /**
- * Returns a Closure for mapping an array with additional data.
+ * Returns a Closure for mapping an array or iterable with additional data arguments
+ * passed to the callback alongside each element's value.
  *
- * @param callable(mixed ...$a):mixed $func
- * @param mixed ...$data
- * @return Closure(mixed[]):mixed[]
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; keys preserved).
+ *
+ * @param callable(mixed ...$a):mixed $func Callback invoked as `$func($value, ...$data)`.
+ * @param mixed ...$data Extra arguments threaded into each invocation of `$func`.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function mapWith(callable $func, ...$data): Closure
 {
     /**
-     * @param mixed[] $array The array to map
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source Array or iterable to map.
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($func, $data): array {
-        return array_map(
-            function ($e) use ($data, $func) {
-                return $func($e, ...$data);
-            },
-            $array
-        );
+    return function (iterable $source) use ($func, $data) {
+        if (is_array($source)) {
+            return array_map(
+                function ($e) use ($data, $func) {
+                    return $func($e, ...$data);
+                },
+                $source
+            );
+        }
+        return (function () use ($source, $func, $data) {
+            foreach ($source as $key => $value) {
+                yield $key => $func($value, ...$data);
+            }
+        })();
     };
 }
 
 /**
- * Returns a Closure for mapping an array with access to value and key.
+ * Returns a Closure for mapping over an array or iterable with access to both value
+ * and key in the callback: `$func($value, $key)`.
  *
- * @param callable(int|string $key, mixed $value):mixed $func
- * @return Closure(mixed[]):mixed[]
+ * Note on keys: for parity with the existing array-path behaviour (which uses
+ * `array_map` with two arrays — causing the result to be numerically re-indexed),
+ * the Generator path also yields sequential integer keys starting at 0.
+ *
+ * - Array in  → array out with sequential numeric keys (unchanged behaviour).
+ * - Generator/Traversable in → Generator out with sequential numeric keys.
+ *
+ * @param callable(mixed $value, int|string $key):mixed $func
+ * @return Closure(iterable<int|string, mixed>):(array<int, mixed>|\Generator<int, mixed>)
  */
 function mapWithKey(callable $func): Closure
 {
     /**
-     * @param mixed[] $array The array to map
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source Array or iterable to map.
+     * @return array<int, mixed>|\Generator<int, mixed>
      */
-    return function (array $array) use ($func): array {
-        return array_map(
-            function ($key, $value) use ($func) {
-                return $func($value, $key);
-            },
-            $array,
-            array_keys($array)
-        );
+    return function (iterable $source) use ($func) {
+        if (is_array($source)) {
+            return array_map(
+                function ($key, $value) use ($func) {
+                    return $func($value, $key);
+                },
+                $source,
+                array_keys($source)
+            );
+        }
+        return (function () use ($source, $func) {
+            $i = 0;
+            foreach ($source as $key => $value) {
+                yield $i++ => $func($value, $key);
+            }
+        })();
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -185,29 +185,45 @@ function toString(?string $glue = null): Closure
 }
 
 /**
- * Creates a Closure for zipping 2 arrays.
+ * Creates a Closure for zipping a source array or iterable with a secondary
+ * array. Each element of the result is a pair — [source_value, additional_value].
+ * When the additional array is shorter than the source, `$default` fills the gap.
  *
- * @param array<mixed> $additional Values with the same key will be paired.
- * @param mixed $default The fallback value if the additional array doesn't have the same length
- * @return Closure(array<mixed>):array<array{mixed, mixed}>
+ * - Array in  → array out (unchanged behaviour).
+ * - Generator/Traversable in → Generator out that yields pairs lazily.
  *
+ * @param array<mixed> $additional Values paired positionally with the source.
+ * @param mixed $default Fallback when the additional array runs out.
+ * @return Closure(iterable<mixed>):(array<array{mixed, mixed}>|\Generator<int, array{mixed, mixed}>)
  */
 function zip(array $additional, $default = null): Closure
 {
     $additional = array_values($additional);
-    return function (array $array) use ($additional, $default) {
-        $array = array_values($array);
-        return array_reduce(
-            array_keys($array),
-            function ($carry, $key) use ($array, $additional, $default): array {
-                $carry[] = array(
-                    $array[$key],
-                    array_key_exists($key, $additional) ? $additional[$key] : $default,
+    return function (iterable $source) use ($additional, $default) {
+        if (is_array($source)) {
+            $source = array_values($source);
+            return array_reduce(
+                array_keys($source),
+                function ($carry, $key) use ($source, $additional, $default): array {
+                    $carry[] = array(
+                        $source[$key],
+                        array_key_exists($key, $additional) ? $additional[$key] : $default,
+                    );
+                    return $carry;
+                },
+                array()
+            );
+        }
+        return (function () use ($source, $additional, $default) {
+            $i = 0;
+            foreach ($source as $value) {
+                yield array(
+                    $value,
+                    array_key_exists($i, $additional) ? $additional[$i] : $default,
                 );
-                return $carry;
-            },
-            array()
-        );
+                $i++;
+            }
+        })();
     };
 }
 
@@ -776,38 +792,92 @@ function groupBy(callable $function): Closure
 }
 
 /**
- * Creates a Closure for chunking an array to set a limit.
+ * Creates a Closure for chunking an array or iterable into batches of up to N.
  *
- * @param int $count The max size of each chunk. Must not be less than 1!
- * @param bool $preserveKeys Should inital keys be kept. Default false.
- * @return Closure(mixed[]):mixed[]
+ * - Array in  → array of arrays (unchanged behaviour via array_chunk).
+ * - Generator/Traversable in → Generator that yields each completed batch as
+ *   an array. The final partial batch is yielded when the source exhausts.
+ *
+ * @param int $count The max size of each chunk. Values less than 1 are
+ *                   clamped to 1.
+ * @param bool $preserveKeys Should the source keys be kept inside each batch.
+ * @return Closure(iterable<int|string, mixed>):(array<int, array<int|string, mixed>>|\Generator<int, array<int|string, mixed>>)
  */
 function chunk(int $count, bool $preserveKeys = false): Closure
 {
+    $count = max(1, $count);
     /**
-     * @param mixed[] $array Array to chunk
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int, array<int|string, mixed>>|\Generator<int, array<int|string, mixed>>
      */
-    return function (array $array) use ($count, $preserveKeys): array {
-        return array_chunk($array, max(1, $count), $preserveKeys);
+    return function (iterable $source) use ($count, $preserveKeys) {
+        if (is_array($source)) {
+            return array_chunk($source, $count, $preserveKeys);
+        }
+        return (function () use ($source, $count, $preserveKeys) {
+            $buffer = array();
+            foreach ($source as $key => $value) {
+                if ($preserveKeys) {
+                    $buffer[$key] = $value;
+                } else {
+                    $buffer[] = $value;
+                }
+                if (count($buffer) >= $count) {
+                    yield $buffer;
+                    $buffer = array();
+                }
+            }
+            if (count($buffer) > 0) {
+                yield $buffer;
+            }
+        })();
     };
 }
 
 /**
- * Create callback for extracting a single column from an array.
+ * Create callback for extracting a single column from an array or iterable of
+ * array/object rows.
+ *
+ * - Array in  → array of extracted values (unchanged behaviour via array_column).
+ * - Generator/Traversable in → Generator that lazily yields the column value
+ *   from each row. If `$key` is provided, each yielded pair is `rowKey => value`;
+ *   otherwise sequential integer keys are used.
  *
  * @param string $column Column to retrieve.
- * @param string $key Use column for assigning as the index. defaults to numeric keys if null.
- * @return Closure(mixed[]):mixed[]
+ * @param string|null $key Column to use as the yielded key. Null = sequential ints.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function column(string $column, ?string $key = null): Closure
 {
     /**
-     * @param mixed[] $array
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($column, $key): array {
-        return array_column($array, $column, $key);
+    return function (iterable $source) use ($column, $key) {
+        if (is_array($source)) {
+            return array_column($source, $column, $key);
+        }
+        return (function () use ($source, $column, $key) {
+            foreach ($source as $row) {
+                $value = null;
+                if (is_array($row) && array_key_exists($column, $row)) {
+                    $value = $row[$column];
+                } elseif (is_object($row) && isset($row->{$column})) {
+                    $value = $row->{$column};
+                }
+                if ($key === null) {
+                    yield $value;
+                    continue;
+                }
+                $rowKey = null;
+                if (is_array($row) && array_key_exists($key, $row)) {
+                    $rowKey = $row[$key];
+                } elseif (is_object($row) && isset($row->{$key})) {
+                    $rowKey = $row->{$key};
+                }
+                yield $rowKey => $value;
+            }
+        })();
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -459,19 +459,31 @@ function filterAny(callable $function): Closure
 
 
 /**
- * Returns a Closure which can be passed an array.
+ * Returns a Closure which applies a callback to every element of an array
+ * or iterable.
  *
- * @param callable(mixed):mixed $func Callback to apply to each element in array.
- * @return Closure(mixed[]):mixed[]
+ * - Array in  → array out (eager, unchanged behaviour).
+ * - Generator/Traversable in → Generator out (lazy; values are transformed
+ *   on demand, keys preserved).
+ *
+ * @param callable(mixed):mixed $func Callback to apply to each element.
+ * @return Closure(iterable<int|string, mixed>):(array<int|string, mixed>|\Generator<int|string, mixed>)
  */
 function map(callable $func): Closure
 {
     /**
-     * @param mixed[] $array The array to map
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source The array or iterable to map.
+     * @return array<int|string, mixed>|\Generator<int|string, mixed>
      */
-    return function (array $array) use ($func): array {
-        return array_map($func, $array);
+    return function (iterable $source) use ($func) {
+        if (is_array($source)) {
+            return array_map($func, $source);
+        }
+        return (function () use ($source, $func) {
+            foreach ($source as $key => $value) {
+                yield $key => $func($value);
+            }
+        })();
     };
 }
 

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -952,7 +952,7 @@ function flattenByN(?int $n = null): Closure
                 if (is_array($element) && empty($element)) {
                     continue;
                 }
-                if (is_array($element) && (is_null($n) || $n > 0)) {
+                if (is_array($element) && (is_null($n) || $n > 0)) { // @phpstan-ignore-line
                     foreach (flattenByN($n ? $n - 1 : null)($element) as $sub) {
                         yield $sub;
                     }

--- a/src/arrays.php
+++ b/src/arrays.php
@@ -722,36 +722,57 @@ function each(callable $func): Closure
 }
 
 /**
- * Returns a Closure for flattening and mapping an array
+ * Returns a Closure for flattening and mapping an array or iterable.
  *
- * @param callable(mixed):mixed $function The function to map the element. (Will no be called if resolves to array)
- * @param int|null $n Depth of nodes to flatten. If null will flatten to n
- * @return Closure(mixed[]):mixed[]
+ * - Array in  → array out (unchanged behaviour via array_reduce/array_merge).
+ * - Generator/Traversable in → Generator out that lazily recurses into nested
+ *   arrays up to depth $n, applying $function to leaf non-array elements.
+ *
+ * @param callable(mixed):mixed $function Applied to leaf non-array elements.
+ * @param int|null $n Recursion depth; null = flatten fully.
+ * @return Closure(iterable<int|string, mixed>):(array<int, mixed>|\Generator<int, mixed>)
  */
 function flatMap(callable $function, ?int $n = null): Closure
 {
     /**
-     * @param mixed[] $array
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int, mixed>|\Generator<int, mixed>
      */
-    return function (array $array) use ($n, $function): array {
-        return array_reduce(
-            $array,
-            /**
-             * @param mixed[] $carry
-             * @param mixed $element
-             * @return mixed[]
-             */
-            function (array $carry, $element) use ($n, $function): array {
+    return function (iterable $source) use ($n, $function) {
+        if (is_array($source)) {
+            return array_reduce(
+                $source,
+                /**
+                 * @param mixed[] $carry
+                 * @param mixed $element
+                 * @return mixed[]
+                 */
+                function (array $carry, $element) use ($n, $function): array {
+                    if (is_array($element) && (is_null($n) || $n > 0)) {
+                        // Recursive call on an array element always hits the array path,
+                        // which returns array. The return type is widened to include
+                        // Generator for iterable inputs; narrow it back here for array_merge.
+                        $recursed = flatMap($function, $n ? $n - 1 : null)($element);
+                        $carry    = array_merge($carry, is_array($recursed) ? $recursed : iterator_to_array($recursed));
+                    } else {
+                        $carry[] = is_array($element) ? $element : $function($element);
+                    }
+                    return $carry;
+                },
+                array()
+            );
+        }
+        return (function () use ($source, $n, $function) {
+            foreach ($source as $element) {
                 if (is_array($element) && (is_null($n) || $n > 0)) {
-                    $carry = array_merge($carry, flatMap($function, $n ? $n - 1 : null)($element));
+                    foreach (flatMap($function, $n ? $n - 1 : null)($element) as $sub) {
+                        yield $sub;
+                    }
                 } else {
-                    $carry[] = is_array($element) ? $element : $function($element);
+                    yield is_array($element) ? $element : $function($element);
                 }
-                return $carry;
-            },
-            array()
-        );
+            }
+        })();
     };
 }
 
@@ -882,41 +903,64 @@ function column(string $column, ?string $key = null): Closure
 }
 
 /**
- * Returns a Closure for flattening an array to a defined depth
+ * Returns a Closure for flattening an array or iterable to a defined depth.
  *
- * @param int|null $n Depth of nodes to flatten. If null will flatten to n
- * @return Closure(mixed[] $var): mixed[]
+ * - Array in  → array out (unchanged behaviour).
+ * - Generator/Traversable in → Generator out that lazily recurses into nested
+ *   arrays up to depth $n. Empty nested arrays are dropped.
+ *
+ * @param int|null $n Depth of nodes to flatten. If null will flatten fully.
+ * @return Closure(iterable<int|string, mixed>):(array<int, mixed>|\Generator<int, mixed>)
  */
 function flattenByN(?int $n = null): Closure
 {
     /**
-     * @param mixed[] $array Array to flatten
-     * @return mixed[]
+     * @param iterable<int|string, mixed> $source
+     * @return array<int, mixed>|\Generator<int, mixed>
      */
-    return function (array $array) use ($n): array {
-        return array_reduce(
-            $array,
-            /**
-             * @param array<int|string, mixed> $carry
-             * @param mixed|mixed[] $element
-             * @return array<int|string, mixed>
-             */
-            function (array $carry, $element) use ($n): array {
-                // Remove empty arrays.
-                if (is_array($element) && empty($element)) {
+    return function (iterable $source) use ($n) {
+        if (is_array($source)) {
+            return array_reduce(
+                $source,
+                /**
+                 * @param array<int|string, mixed> $carry
+                 * @param mixed|mixed[] $element
+                 * @return array<int|string, mixed>
+                 */
+                function (array $carry, $element) use ($n): array {
+                    // Remove empty arrays.
+                    if (is_array($element) && empty($element)) {
+                        return $carry;
+                    }
+                    // If the element is an array and we are still flattening, call again
+                    if (is_array($element) && (is_null($n) || $n > 0)) { // @phpstan-ignore-line
+                        // Recursion on an array hits the array path; narrow the widened
+                        // array|Generator return back to array for array_merge.
+                        $recursed = flattenByN($n ? $n - 1 : null)($element);
+                        $carry    = array_merge($carry, is_array($recursed) ? $recursed : iterator_to_array($recursed));
+                    } else {
+                        // Else just add the element.
+                        $carry[] = $element;
+                    }
                     return $carry;
+                },
+                array()
+            );
+        }
+        return (function () use ($source, $n) {
+            foreach ($source as $element) {
+                if (is_array($element) && empty($element)) {
+                    continue;
                 }
-                // If the element is an array and we are still flattening, call again
-                if (is_array($element) && (is_null($n) || $n > 0)) { // @phpstan-ignore-line
-                    $carry = array_merge($carry, flattenByN($n ? $n - 1 : null)($element));
+                if (is_array($element) && (is_null($n) || $n > 0)) {
+                    foreach (flattenByN($n ? $n - 1 : null)($element) as $sub) {
+                        yield $sub;
+                    }
                 } else {
-                    // Else just add the element.
-                    $carry[] = $element;
+                    yield $element;
                 }
-                return $carry;
-            },
-            array()
-        );
+            }
+        })();
     };
 }
 

--- a/src/procedural.php
+++ b/src/procedural.php
@@ -50,7 +50,11 @@ if (! function_exists('array_flatten')) {
      */
     function arrayFlatten(array $array, ?int $n = null): array
     {
-        return Arr\flattenByN($n)($array);
+        // Arr\flattenByN returns array when given an array, but its return type
+        // was widened in 1.0.0 to include Generator for iterable inputs.
+        // Narrow here — callers still expect an array.
+        $result = Arr\flattenByN($n)($array);
+        return is_array($result) ? $result : iterator_to_array($result);
     }
 }
 

--- a/src/procedural.php
+++ b/src/procedural.php
@@ -50,9 +50,6 @@ if (! function_exists('array_flatten')) {
      */
     function arrayFlatten(array $array, ?int $n = null): array
     {
-        // Arr\flattenByN returns array when given an array, but its return type
-        // was widened in 1.0.0 to include Generator for iterable inputs.
-        // Narrow here — callers still expect an array.
         $result = Arr\flattenByN($n)($array);
         return is_array($result) ? $result : iterator_to_array($result);
     }


### PR DESCRIPTION
This pull request introduces comprehensive iterable support to all data-transforming functions in the `Arrays namespace, allowing them to accept any `iterable` (arrays, Generators, Iterators, Traversables) and to return either arrays or Generators as appropriate. The changes are extensively documented in the `README.md` and are backed by a broad suite of new and enhanced tests that verify correct lazy and terminal behavior, short-circuiting, and compatibility with both arrays and Generators.

**Iterable support and documentation:**

* Added a detailed "Iterable support" section to `README.md`, explaining the new contract for `Arrays\*` functions, including lazy vs. terminal functions, caveats, and usage examples.
* Updated the changelog in `README.md` to highlight iterable support and backward compatibility, with references to the new documentation section.

**Testing helpers:**

* Added `gen` and `genThrowAt` helpers to `Tests/arrays/test-array-filter-and-map.php` and `Tests/test-arrays.php` to facilitate testing with Generators and to verify lazy, short-circuiting behavior. [[1]](diffhunk://#diff-322da440eb273144558a56a54c5bc1e8ad9bfc036c1b1409055b171dd7e5e47cR29-R60) [[2]](diffhunk://#diff-5236167ff3a74daebc8f2ab850f8333eb6e52e9b6834a0c9ebd0cb7f7bbaac1aR45-R76)

**Expanded and improved test coverage for iterable support:**

* Added or enhanced tests for all relevant `Arrays\*` functions (`map`, `filter`, `filterKey`, `filterAnd`, `filterOr`, `filterMap`, `mapKey`, `mapWith`, `mapWithKey`, `flatMap`, `append`, `prepend`, `head`, `last`, `tail`, `chunk`, `zip`, `column`) to ensure correct behavior with both arrays and Generators, including checks for laziness and key preservation. [[1]](diffhunk://#diff-322da440eb273144558a56a54c5bc1e8ad9bfc036c1b1409055b171dd7e5e47cR206-R231) [[2]](diffhunk://#diff-322da440eb273144558a56a54c5bc1e8ad9bfc036c1b1409055b171dd7e5e47cR291-R432) [[3]](diffhunk://#diff-322da440eb273144558a56a54c5bc1e8ad9bfc036c1b1409055b171dd7e5e47cR465-R484) [[4]](diffhunk://#diff-5236167ff3a74daebc8f2ab850f8333eb6e52e9b6834a0c9ebd0cb7f7bbaac1aR109-R145) [[5]](diffhunk://#diff-5236167ff3a74daebc8f2ab850f8333eb6e52e9b6834a0c9ebd0cb7f7bbaac1aR175-R209) [[6]](diffhunk://#diff-5236167ff3a74daebc8f2ab850f8333eb6e52e9b6834a0c9ebd0cb7f7bbaac1aR276-R297) [[7]](diffhunk://#diff-5236167ff3a74daebc8f2ab850f8333eb6e52e9b6834a0c9ebd0cb7f7bbaac1aR315-R327) [[8]](diffhunk://#diff-5236167ff3a74daebc8f2ab850f8333eb6e52e9b6834a0c9ebd0cb7f7bbaac1aR387-R406)

These changes ensure that the library is now fully compatible with any iterable input, supports lazy processing where appropriate, and maintains backward compatibility for existing array-based usage.